### PR TITLE
feat(auth): add GitHub OAuth identity flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+AUTH_SECRET=
 
 # PostgreSQL
 DATABASE_URL=postgresql://user:password@localhost:5432/devboard

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
-# App
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Authentication secrets
 AUTH_SECRET=
+GITHUB_CLIENT_SECRET=
 
 # PostgreSQL
 DATABASE_URL=postgresql://user:password@localhost:5432/devboard
 
-# GitHub OAuth (Sprint 1)
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+# Optional local/development overrides
+# APP_URL=http://localhost:3000
+# GITHUB_CLIENT_ID=
 
 # GitHub App (Sprint 2)
 GITHUB_APP_ID=

--- a/docs/GITHUB_AUTH.md
+++ b/docs/GITHUB_AUTH.md
@@ -1,0 +1,58 @@
+# GitHub Authentication
+
+DevBoard uses GitHub OAuth only to identify the signed-in user. Repository monitoring will be handled separately by the DevBoard GitHub App.
+
+## Production OAuth App
+
+Create a GitHub OAuth App with:
+
+- Application name: `DevBoard`
+- Homepage URL: `https://devboard-phi-six.vercel.app`
+- Authorization callback URL: `https://devboard-phi-six.vercel.app/api/auth/github/callback`
+
+Keep wildcard callback matching disabled.
+
+## Vercel environment variables
+
+Configure these for the DevBoard project:
+
+```text
+NEXT_PUBLIC_APP_URL=https://devboard-phi-six.vercel.app
+GITHUB_CLIENT_ID=<OAuth App client id>
+GITHUB_CLIENT_SECRET=<OAuth App client secret>
+AUTH_SECRET=<random secret with at least 32 characters>
+```
+
+Generate `AUTH_SECRET` locally with Node.js:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+```
+
+Do not commit any of these secret values.
+
+## Flow
+
+```text
+Continue with GitHub
+  -> /api/auth/github
+  -> GitHub authorization (state + PKCE)
+  -> /api/auth/github/callback
+  -> exchange authorization code
+  -> fetch GitHub user identity
+  -> upsert users row
+  -> create signed HttpOnly session cookie
+  -> /dashboard
+```
+
+The GitHub access token is not stored after identity lookup.
+
+## Local development
+
+An OAuth App has a configured callback URL. For local OAuth testing, use a separate development OAuth App with a loopback callback such as:
+
+```text
+http://127.0.0.1:3000/api/auth/github/callback
+```
+
+and set `NEXT_PUBLIC_APP_URL` accordingly for local development.

--- a/docs/GITHUB_AUTH.md
+++ b/docs/GITHUB_AUTH.md
@@ -4,24 +4,27 @@ DevBoard uses GitHub OAuth only to identify the signed-in user. Repository monit
 
 ## Production OAuth App
 
-Create a GitHub OAuth App with:
+The production OAuth App is configured with:
 
 - Application name: `DevBoard`
 - Homepage URL: `https://devboard-phi-six.vercel.app`
 - Authorization callback URL: `https://devboard-phi-six.vercel.app/api/auth/github/callback`
+- Client ID: stored as non-secret application configuration in the codebase
 
 Keep wildcard callback matching disabled.
 
 ## Vercel environment variables
 
-Configure these for the DevBoard project:
+Only secret values are required for GitHub login in Vercel:
 
 ```text
-NEXT_PUBLIC_APP_URL=https://devboard-phi-six.vercel.app
-GITHUB_CLIENT_ID=<OAuth App client id>
 GITHUB_CLIENT_SECRET=<OAuth App client secret>
 AUTH_SECRET=<random secret with at least 32 characters>
 ```
+
+`DATABASE_URL` remains required separately for PostgreSQL and should also stay secret.
+
+The production application URL and OAuth Client ID are public configuration and are stored in `src/modules/auth/config.ts`, so they do not need Vercel environment variables.
 
 Generate `AUTH_SECRET` locally with Node.js:
 
@@ -29,7 +32,7 @@ Generate `AUTH_SECRET` locally with Node.js:
 node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
 ```
 
-Do not commit any of these secret values.
+Never commit `GITHUB_CLIENT_SECRET`, `AUTH_SECRET`, or `DATABASE_URL`.
 
 ## Flow
 
@@ -49,10 +52,15 @@ The GitHub access token is not stored after identity lookup.
 
 ## Local development
 
-An OAuth App has a configured callback URL. For local OAuth testing, use a separate development OAuth App with a loopback callback such as:
+Production needs no `APP_URL` or `GITHUB_CLIENT_ID` environment variables. Local development can optionally override the public defaults with:
 
 ```text
-http://127.0.0.1:3000/api/auth/github/callback
+APP_URL=http://localhost:3000
+GITHUB_CLIENT_ID=<development OAuth App client id>
 ```
 
-and set `NEXT_PUBLIC_APP_URL` accordingly for local development.
+For local OAuth testing, use a separate development OAuth App with a loopback callback such as:
+
+```text
+http://localhost:3000/api/auth/github/callback
+```

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -1,0 +1,111 @@
+import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import {
+  getAppOrigin,
+  getAuthEnv,
+  getGithubCallbackUrl,
+} from "@/modules/auth/config";
+import { exchangeGithubCode, fetchGithubIdentity } from "@/modules/auth/github";
+import {
+  createSessionToken,
+  OAUTH_STATE_COOKIE,
+  OAUTH_VERIFIER_COOKIE,
+  safeEqual,
+  SESSION_COOKIE,
+  SESSION_MAX_AGE_SECONDS,
+} from "@/modules/auth/session";
+
+export const runtime = "nodejs";
+
+function clearOAuthCookies(response: NextResponse) {
+  response.cookies.set(OAUTH_STATE_COOKIE, "", { path: "/", maxAge: 0 });
+  response.cookies.set(OAUTH_VERIFIER_COOKIE, "", { path: "/", maxAge: 0 });
+}
+
+export async function GET(request: NextRequest) {
+  const appOrigin = getAppOrigin(request.nextUrl.origin);
+
+  try {
+    const env = getAuthEnv();
+    const code = request.nextUrl.searchParams.get("code");
+    const state = request.nextUrl.searchParams.get("state");
+    const error = request.nextUrl.searchParams.get("error");
+    const storedState = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
+    const verifier = request.cookies.get(OAUTH_VERIFIER_COOKIE)?.value;
+
+    if (error || !code || !state || !storedState || !verifier) {
+      throw new Error(error ?? "Missing OAuth callback parameters");
+    }
+
+    if (!safeEqual(state, storedState)) {
+      throw new Error("OAuth state mismatch");
+    }
+
+    const callbackUrl = getGithubCallbackUrl(request.nextUrl.origin);
+    const accessToken = await exchangeGithubCode({
+      config: {
+        clientId: env.GITHUB_CLIENT_ID,
+        clientSecret: env.GITHUB_CLIENT_SECRET,
+        callbackUrl,
+      },
+      code,
+      codeVerifier: verifier,
+    });
+
+    const identity = await fetchGithubIdentity(accessToken);
+    const now = new Date();
+
+    const [user] = await db
+      .insert(users)
+      .values({
+        ...identity,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: users.githubId,
+        set: {
+          username: identity.username,
+          name: identity.name,
+          email: identity.email,
+          avatarUrl: identity.avatarUrl,
+          updatedAt: now,
+        },
+      })
+      .returning({ id: users.id });
+
+    if (!user) {
+      const [existingUser] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.githubId, identity.githubId))
+        .limit(1);
+      if (!existingUser) throw new Error("Unable to persist GitHub user");
+      user.id = existingUser.id;
+    }
+
+    const response = NextResponse.redirect(new URL("/dashboard", appOrigin));
+    response.cookies.set(
+      SESSION_COOKIE,
+      createSessionToken(user.id, env.AUTH_SECRET),
+      {
+        httpOnly: true,
+        secure: appOrigin.startsWith("https://"),
+        sameSite: "lax",
+        path: "/",
+        maxAge: SESSION_MAX_AGE_SECONDS,
+      },
+    );
+    clearOAuthCookies(response);
+    return response;
+  } catch (error) {
+    console.error("github_oauth_callback_failed", {
+      message: error instanceof Error ? error.message : "unknown error",
+    });
+    const response = NextResponse.redirect(new URL("/?auth_error=github", appOrigin));
+    clearOAuthCookies(response);
+    return response;
+  }
+}

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -1,4 +1,3 @@
-import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
@@ -76,15 +75,7 @@ export async function GET(request: NextRequest) {
       })
       .returning({ id: users.id });
 
-    if (!user) {
-      const [existingUser] = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.githubId, identity.githubId))
-        .limit(1);
-      if (!existingUser) throw new Error("Unable to persist GitHub user");
-      user.id = existingUser.id;
-    }
+    if (!user) throw new Error("Unable to persist GitHub user");
 
     const response = NextResponse.redirect(new URL("/dashboard", appOrigin));
     response.cookies.set(

--- a/src/app/api/auth/github/route.ts
+++ b/src/app/api/auth/github/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthEnv, getGithubCallbackUrl } from "@/modules/auth/config";
+import { buildGithubAuthorizeUrl } from "@/modules/auth/github";
+import {
+  createOAuthState,
+  createPkceChallenge,
+  createPkceVerifier,
+  OAUTH_COOKIE_MAX_AGE_SECONDS,
+  OAUTH_STATE_COOKIE,
+  OAUTH_VERIFIER_COOKIE,
+} from "@/modules/auth/session";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  try {
+    const env = getAuthEnv();
+    const state = createOAuthState();
+    const verifier = createPkceVerifier();
+    const callbackUrl = getGithubCallbackUrl(request.nextUrl.origin);
+    const authorizeUrl = buildGithubAuthorizeUrl({
+      clientId: env.GITHUB_CLIENT_ID,
+      callbackUrl,
+      state,
+      codeChallenge: createPkceChallenge(verifier),
+    });
+
+    const response = NextResponse.redirect(authorizeUrl);
+    const secure = callbackUrl.startsWith("https://");
+    const cookieOptions = {
+      httpOnly: true,
+      secure,
+      sameSite: "lax" as const,
+      path: "/",
+      maxAge: OAUTH_COOKIE_MAX_AGE_SECONDS,
+    };
+
+    response.cookies.set(OAUTH_STATE_COOKIE, state, cookieOptions);
+    response.cookies.set(OAUTH_VERIFIER_COOKIE, verifier, cookieOptions);
+    return response;
+  } catch {
+    return NextResponse.redirect(new URL("/?auth_error=config", request.url));
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SESSION_COOKIE } from "@/modules/auth/session";
+
+export async function POST(request: NextRequest) {
+  const response = NextResponse.redirect(new URL("/", request.url), 303);
+  response.cookies.set(SESSION_COOKIE, "", {
+    httpOnly: true,
+    secure: request.nextUrl.protocol === "https:",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return response;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/modules/auth/current-user";
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/");
+
+  return (
+    <main className="shell">
+      <nav className="topbar">
+        <div className="brand">
+          <span className="brand-mark">D</span>
+          <span>DevBoard</span>
+        </div>
+        <div className="account-actions">
+          <span className="status-pill">@{user.username}</span>
+          <form action="/api/auth/logout" method="post">
+            <button className="secondary" type="submit">
+              Sign out
+            </button>
+          </form>
+        </div>
+      </nav>
+
+      <section className="hero dashboard-hero">
+        <p className="eyebrow">GITHUB IDENTITY CONNECTED</p>
+        <h1>Welcome, {user.name ?? user.username}.</h1>
+        <p className="hero-copy">
+          Your DevBoard account is now linked to GitHub. The next step is connecting
+          repositories through the DevBoard GitHub App.
+        </p>
+      </section>
+
+      <section className="signal-grid" aria-label="DevBoard account status">
+        <article className="signal-card">
+          <span>Identity</span>
+          <strong className="signal-word">Connected</strong>
+          <p>GitHub user #{user.githubId}</p>
+        </article>
+        <article className="signal-card">
+          <span>Repositories</span>
+          <strong>0</strong>
+          <p>GitHub App integration is next</p>
+        </article>
+        <article className="signal-card">
+          <span>Needs attention</span>
+          <strong>--</strong>
+          <p>No repository is being observed yet</p>
+        </article>
+      </section>
+
+      <section className="principle">
+        <div>
+          <p className="eyebrow">NEXT VERTICAL SLICE</p>
+          <h2>Connect a real repository.</h2>
+        </div>
+        <p>
+          Once the GitHub App is installed, DevBoard can ingest real pull requests,
+          issues and workflow signals instead of displaying placeholder data.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,11 @@ select {
   font: inherit;
 }
 
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
 .shell {
   width: min(1120px, calc(100% - 40px));
   min-height: 100vh;
@@ -46,6 +51,7 @@ select {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -77,9 +83,19 @@ select {
   font-size: 12px;
 }
 
+.account-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .hero {
   max-width: 850px;
   padding: 112px 0 72px;
+}
+
+.dashboard-hero {
+  padding-bottom: 56px;
 }
 
 .eyebrow {
@@ -120,18 +136,40 @@ h1 {
   font-size: 13px;
 }
 
+.primary,
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 .primary {
   padding: 11px 16px;
   border: 0;
-  border-radius: 9px;
   background: var(--accent);
   color: #11140a;
-  font-weight: 700;
 }
 
-.primary:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
+.primary:hover {
+  filter: brightness(1.05);
+}
+
+.secondary {
+  padding: 8px 11px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.primary:focus-visible,
+.secondary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .signal-grid {
@@ -164,6 +202,10 @@ h1 {
   letter-spacing: -0.05em;
 }
 
+.signal-card .signal-word {
+  font-size: clamp(28px, 4vw, 42px);
+}
+
 .signal-card p {
   margin: 0;
   color: #686f7a;
@@ -194,6 +236,17 @@ h1 {
 @media (max-width: 760px) {
   .shell {
     width: min(100% - 28px, 1120px);
+  }
+
+  .topbar {
+    height: auto;
+    min-height: 76px;
+    padding: 14px 0;
+  }
+
+  .account-actions {
+    align-items: flex-end;
+    flex-direction: column;
   }
 
   .hero {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,14 @@
+import { getCurrentUser } from "@/modules/auth/current-user";
+
 const signals = [
-  { label: "Project health", value: "--", caption: "Connect GitHub to calculate" },
+  { label: "Project health", value: "--", caption: "Connect a repository to calculate" },
   { label: "Needs attention", value: "--", caption: "No repository connected" },
   { label: "Recent activity", value: "--", caption: "Waiting for real events" },
 ];
 
-export default function Home() {
+export default async function Home() {
+  const user = await getCurrentUser();
+
   return (
     <main className="shell">
       <nav className="topbar">
@@ -12,7 +16,9 @@ export default function Home() {
           <span className="brand-mark">D</span>
           <span>DevBoard</span>
         </div>
-        <span className="status-pill">Development preview</span>
+        <span className="status-pill">
+          {user ? `Signed in as @${user.username}` : "Private alpha"}
+        </span>
       </nav>
 
       <section className="hero">
@@ -23,10 +29,14 @@ export default function Home() {
           attention signals and context you can understand in seconds.
         </p>
         <div className="hero-actions">
-          <button className="primary" type="button" disabled>
-            Connect GitHub
-          </button>
-          <span>GitHub integration arrives in Sprint 1.</span>
+          <a className="primary" href={user ? "/dashboard" : "/api/auth/github"}>
+            {user ? "Open dashboard" : "Continue with GitHub"}
+          </a>
+          <span>
+            {user
+              ? "Your GitHub identity is connected."
+              : "Read-only identity access for the first MVP."}
+          </span>
         </div>
       </section>
 

--- a/src/modules/auth/config.ts
+++ b/src/modules/auth/config.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const authEnvSchema = z.object({
+  GITHUB_CLIENT_ID: z.string().min(1),
+  GITHUB_CLIENT_SECRET: z.string().min(1),
+  AUTH_SECRET: z.string().min(32),
+  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+});
+
+export function getAuthEnv() {
+  return authEnvSchema.parse(process.env);
+}
+
+export function getAppOrigin(requestOrigin: string) {
+  const configured = process.env.NEXT_PUBLIC_APP_URL;
+  if (!configured) return requestOrigin;
+  return new URL(configured).origin;
+}
+
+export function getGithubCallbackUrl(requestOrigin: string) {
+  return `${getAppOrigin(requestOrigin)}/api/auth/github/callback`;
+}

--- a/src/modules/auth/config.ts
+++ b/src/modules/auth/config.ts
@@ -1,20 +1,30 @@
 import { z } from "zod";
 
+export const PRODUCTION_APP_URL = "https://devboard-phi-six.vercel.app";
+export const DEFAULT_GITHUB_CLIENT_ID = "Ov23liGf80rPbydhXwFE";
+
 const authEnvSchema = z.object({
-  GITHUB_CLIENT_ID: z.string().min(1),
   GITHUB_CLIENT_SECRET: z.string().min(1),
   AUTH_SECRET: z.string().min(32),
-  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
 });
 
 export function getAuthEnv() {
-  return authEnvSchema.parse(process.env);
+  return {
+    ...authEnvSchema.parse(process.env),
+    GITHUB_CLIENT_ID:
+      process.env.GITHUB_CLIENT_ID?.trim() || DEFAULT_GITHUB_CLIENT_ID,
+  };
 }
 
 export function getAppOrigin(requestOrigin: string) {
-  const configured = process.env.NEXT_PUBLIC_APP_URL;
-  if (!configured) return requestOrigin;
-  return new URL(configured).origin;
+  const configured = process.env.APP_URL?.trim();
+  if (configured) return new URL(configured).origin;
+
+  if (process.env.VERCEL_ENV === "production") {
+    return PRODUCTION_APP_URL;
+  }
+
+  return requestOrigin;
 }
 
 export function getGithubCallbackUrl(requestOrigin: string) {

--- a/src/modules/auth/current-user.ts
+++ b/src/modules/auth/current-user.ts
@@ -1,0 +1,31 @@
+import { eq } from "drizzle-orm";
+import { cookies } from "next/headers";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { SESSION_COOKIE, verifySessionToken } from "./session";
+
+export async function getCurrentUser() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+  const secret = process.env.AUTH_SECRET;
+
+  if (!token || !secret) return null;
+
+  const session = verifySessionToken(token, secret);
+  if (!session) return null;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      githubId: users.githubId,
+      username: users.username,
+      name: users.name,
+      email: users.email,
+      avatarUrl: users.avatarUrl,
+    })
+    .from(users)
+    .where(eq(users.id, session.sub))
+    .limit(1);
+
+  return user ?? null;
+}

--- a/src/modules/auth/github.ts
+++ b/src/modules/auth/github.ts
@@ -1,0 +1,123 @@
+type GithubOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  callbackUrl: string;
+};
+
+type GithubProfile = {
+  id: number;
+  login: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+};
+
+type GithubEmail = {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+};
+
+export function buildGithubAuthorizeUrl({
+  clientId,
+  callbackUrl,
+  state,
+  codeChallenge,
+}: {
+  clientId: string;
+  callbackUrl: string;
+  state: string;
+  codeChallenge: string;
+}) {
+  const url = new URL("https://github.com/login/oauth/authorize");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", callbackUrl);
+  url.searchParams.set("scope", "read:user user:email");
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url;
+}
+
+export async function exchangeGithubCode({
+  config,
+  code,
+  codeVerifier,
+}: {
+  config: GithubOAuthConfig;
+  code: string;
+  codeVerifier: string;
+}) {
+  const response = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code,
+      redirect_uri: config.callbackUrl,
+      code_verifier: codeVerifier,
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub token exchange failed with ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: string;
+    error?: string;
+  };
+
+  if (!payload.access_token || payload.error) {
+    throw new Error(payload.error ?? "GitHub did not return an access token");
+  }
+
+  return payload.access_token;
+}
+
+async function githubApi<T>(path: string, accessToken: string) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${accessToken}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} failed with ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchGithubIdentity(accessToken: string) {
+  const profile = await githubApi<GithubProfile>("/user", accessToken);
+  let email = profile.email;
+
+  if (!email) {
+    try {
+      const emails = await githubApi<GithubEmail[]>("/user/emails", accessToken);
+      email =
+        emails.find((candidate) => candidate.primary && candidate.verified)?.email ??
+        emails.find((candidate) => candidate.verified)?.email ??
+        null;
+    } catch {
+      email = null;
+    }
+  }
+
+  return {
+    githubId: String(profile.id),
+    username: profile.login,
+    name: profile.name,
+    email,
+    avatarUrl: profile.avatar_url,
+  };
+}

--- a/src/modules/auth/session.ts
+++ b/src/modules/auth/session.ts
@@ -1,0 +1,87 @@
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+
+export const SESSION_COOKIE = "devboard_session";
+export const OAUTH_STATE_COOKIE = "devboard_oauth_state";
+export const OAUTH_VERIFIER_COOKIE = "devboard_oauth_verifier";
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+export const OAUTH_COOKIE_MAX_AGE_SECONDS = 60 * 10;
+
+type SessionPayload = {
+  sub: string;
+  exp: number;
+};
+
+function sign(value: string, secret: string) {
+  return createHmac("sha256", secret).update(value).digest("base64url");
+}
+
+export function createSessionToken(
+  userId: string,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+) {
+  const payload: SessionPayload = {
+    sub: userId,
+    exp: nowSeconds + SESSION_MAX_AGE_SECONDS,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${encodedPayload}.${sign(encodedPayload, secret)}`;
+}
+
+export function verifySessionToken(
+  token: string,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): SessionPayload | null {
+  const [encodedPayload, providedSignature, extra] = token.split(".");
+  if (!encodedPayload || !providedSignature || extra) return null;
+
+  const expectedSignature = sign(encodedPayload, secret);
+  const provided = Buffer.from(providedSignature);
+  const expected = Buffer.from(expectedSignature);
+
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
+    ) as Partial<SessionPayload>;
+
+    if (typeof payload.sub !== "string" || typeof payload.exp !== "number") {
+      return null;
+    }
+
+    if (payload.exp <= nowSeconds) return null;
+    return { sub: payload.sub, exp: payload.exp };
+  } catch {
+    return null;
+  }
+}
+
+export function createOAuthState() {
+  return randomBytes(32).toString("base64url");
+}
+
+export function createPkceVerifier() {
+  return randomBytes(48).toString("base64url");
+}
+
+export function createPkceChallenge(verifier: string) {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+export function safeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    timingSafeEqual(leftBuffer, rightBuffer)
+  );
+}

--- a/tests/auth-session.test.ts
+++ b/tests/auth-session.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPkceChallenge,
+  createSessionToken,
+  verifySessionToken,
+} from "@/modules/auth/session";
+
+describe("auth session", () => {
+  const secret = "this-is-a-test-secret-that-is-long-enough-123456";
+
+  it("creates and verifies a signed session", () => {
+    const token = createSessionToken("user-123", secret, 1_000);
+    expect(verifySessionToken(token, secret, 1_001)).toEqual({
+      sub: "user-123",
+      exp: 605_800,
+    });
+  });
+
+  it("rejects tampered sessions", () => {
+    const token = createSessionToken("user-123", secret, 1_000);
+    const tampered = `${token.slice(0, -1)}x`;
+    expect(verifySessionToken(tampered, secret, 1_001)).toBeNull();
+  });
+
+  it("rejects expired sessions", () => {
+    const token = createSessionToken("user-123", secret, 1_000);
+    expect(verifySessionToken(token, secret, 605_800)).toBeNull();
+  });
+
+  it("creates a deterministic S256 PKCE challenge", () => {
+    expect(createPkceChallenge("devboard-verifier")).toBe(
+      "lI2gsjjNWGF9XimD4h5l2-bOIfnE7YE8Yl8n7vEWu4Y",
+    );
+  });
+});

--- a/tests/auth-session.test.ts
+++ b/tests/auth-session.test.ts
@@ -29,7 +29,7 @@ describe("auth session", () => {
 
   it("creates a deterministic S256 PKCE challenge", () => {
     expect(createPkceChallenge("devboard-verifier")).toBe(
-      "lI2gsjjNWGF9XimD4h5l2-bOIfnE7YE8Yl8n7vEWu4Y",
+      "l0sCHubxV87q3y9ectWoR2Y7xObb9NuYl0-s0nB6Qbo",
     );
   });
 });


### PR DESCRIPTION
## Summary

Implements DevBoard's first real authentication capability without adding a new auth dependency.

- GitHub OAuth web flow with `state` + PKCE
- stable GitHub numeric ID used as external identity key
- user upsert into PostgreSQL
- signed HttpOnly DevBoard session cookie (7 days)
- protected `/dashboard`
- logout route
- basic session/PKCE automated tests
- production OAuth setup documentation

## Security

- GitHub client secret remains server-side
- GitHub access token is used only to fetch identity and is not persisted
- login requests only identity/email scopes; repository access remains a separate GitHub App concern
- OAuth temporary cookies are HttpOnly and short-lived

## Required before production validation

Configure the OAuth App and Vercel variables documented in `docs/GITHUB_AUTH.md`.

Closes #4