### PR TITLE
feat(attention): turn GitHub signals into actionable attention

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
-import { count, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
 import {
+  attentionItems,
   githubAppConfigurations,
   githubIssues,
   githubPullRequests,
@@ -35,7 +36,7 @@ export default async function DashboardPage() {
 
   const repositoryCount = connectedRepositories.length;
 
-  const [[pullRequestMetric], [issueMetric], [workflowMetric]] = await Promise.all([
+  const [[pullRequestMetric], [issueMetric], [workflowMetric], activeAttention] = await Promise.all([
     db
       .select({ value: count() })
       .from(githubPullRequests)
@@ -54,11 +55,26 @@ export default async function DashboardPage() {
       .innerJoin(repositories, eq(repositories.id, githubWorkflowRuns.repositoryId))
       .innerJoin(projects, eq(projects.id, repositories.projectId))
       .where(eq(projects.userId, user.id)),
+    db
+      .select({
+        id: attentionItems.id,
+        severity: attentionItems.severity,
+        message: attentionItems.message,
+        detectedAt: attentionItems.detectedAt,
+        owner: repositories.owner,
+        name: repositories.name,
+      })
+      .from(attentionItems)
+      .innerJoin(repositories, eq(repositories.id, attentionItems.repositoryId))
+      .innerJoin(projects, eq(projects.id, repositories.projectId))
+      .where(and(eq(projects.userId, user.id), eq(attentionItems.status, "ACTIVE")))
+      .orderBy(desc(attentionItems.detectedAt)),
   ]);
 
   const pullRequestCount = pullRequestMetric?.value ?? 0;
   const issueCount = issueMetric?.value ?? 0;
   const workflowRunCount = workflowMetric?.value ?? 0;
+  const attentionCount = activeAttention.length;
   const hasSyncedData = connectedRepositories.some((repository) => repository.lastSyncedAt);
 
   return (
@@ -83,7 +99,7 @@ export default async function DashboardPage() {
         <h1>Welcome, {user.name ?? user.username}.</h1>
         <p className="hero-copy">
           {hasSyncedData
-            ? "DevBoard is now reading normalized engineering signals from your GitHub repositories."
+            ? "DevBoard is reading normalized engineering signals and converting them into deterministic attention."
             : repositoryCount > 0
               ? "Your first repository is connected. Run the initial sync to import pull requests, issues, reviews and workflows."
               : "Your DevBoard account is linked to GitHub. Connect the DevBoard GitHub App to start observing real repositories."}
@@ -118,23 +134,47 @@ export default async function DashboardPage() {
           <p>{hasSyncedData ? "Normalized from GitHub" : "Waiting for initial sync"}</p>
         </article>
         <article className="signal-card">
-          <span>Issues</span>
-          <strong>{issueCount}</strong>
-          <p>{hasSyncedData ? `${workflowRunCount} workflow runs imported` : "Waiting for initial sync"}</p>
+          <span>Needs attention</span>
+          <strong>{hasSyncedData ? attentionCount : "--"}</strong>
+          <p>
+            {hasSyncedData
+              ? `${issueCount} issues · ${workflowRunCount} workflow runs observed`
+              : "Waiting for initial sync"}
+          </p>
         </article>
       </section>
 
       <section className="principle">
         <div>
-          <p className="eyebrow">{hasSyncedData ? "NEXT VERTICAL SLICE" : "INITIAL SYNC"}</p>
-          <h2>{hasSyncedData ? "Turn signals into attention." : "Import real engineering signals."}</h2>
+          <p className="eyebrow">{hasSyncedData ? "ATTENTION ENGINE" : "INITIAL SYNC"}</p>
+          <h2>{hasSyncedData ? "Know what needs attention." : "Import real engineering signals."}</h2>
         </div>
         <p>
           {hasSyncedData
-            ? "The data layer is live. Next, deterministic attention rules will decide which pull requests, issues and workflows actually need your attention."
+            ? "DevBoard currently evaluates explainable rules for pull requests waiting on review, stale issues and failed workflows."
             : "Sync uses a short-lived GitHub App installation token. DevBoard never stores that token in PostgreSQL."}
         </p>
       </section>
+
+      {hasSyncedData ? (
+        <section className="repository-list" aria-label="Active attention items">
+          {activeAttention.length > 0 ? (
+            activeAttention.map((item) => (
+              <article className="signal-card" key={item.id}>
+                <span>{item.severity} · {item.owner}/{item.name}</span>
+                <strong className="signal-word">{item.message}</strong>
+                <p>Detected: {item.detectedAt.toISOString()}</p>
+              </article>
+            ))
+          ) : (
+            <article className="signal-card">
+              <span>Attention</span>
+              <strong className="signal-word">No active signals.</strong>
+              <p>The current deterministic rules did not find anything requiring attention.</p>
+            </article>
+          )}
+        </section>
+      ) : null}
 
       {connectedRepositories.length > 0 ? (
         <section className="repository-list" aria-label="Connected repositories">

--- a/src/modules/attention/engine.ts
+++ b/src/modules/attention/engine.ts
@@ -1,0 +1,141 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  attentionItems,
+  githubIssues,
+  githubPullRequests,
+  githubWorkflowRuns,
+  repositories,
+} from "@/db/schema";
+import {
+  evaluateIssue,
+  evaluatePullRequest,
+  evaluateWorkflows,
+  type AttentionFinding,
+} from "@/modules/attention/rules";
+
+const RULE_IDS = ["PR_WAITING_REVIEW", "STALE_ISSUE", "WORKFLOW_FAILED"] as const;
+
+export async function evaluateRepositoryAttention(repositoryId: string, now = new Date()) {
+  const [repository] = await db
+    .select({ projectId: repositories.projectId })
+    .from(repositories)
+    .where(eq(repositories.id, repositoryId))
+    .limit(1);
+
+  if (!repository) throw new Error("Repository not found for attention evaluation");
+
+  const [pullRequests, issues, workflowRuns] = await Promise.all([
+    db
+      .select({
+        githubId: githubPullRequests.githubPullRequestId,
+        number: githubPullRequests.number,
+        state: githubPullRequests.state,
+        draft: githubPullRequests.draft,
+        createdAt: githubPullRequests.createdAtGithub,
+        firstReviewAt: githubPullRequests.firstReviewAt,
+      })
+      .from(githubPullRequests)
+      .where(eq(githubPullRequests.repositoryId, repositoryId)),
+    db
+      .select({
+        githubId: githubIssues.githubIssueId,
+        number: githubIssues.number,
+        state: githubIssues.state,
+        lastActivityAt: githubIssues.lastActivityAt,
+      })
+      .from(githubIssues)
+      .where(eq(githubIssues.repositoryId, repositoryId)),
+    db
+      .select({
+        githubRunId: githubWorkflowRuns.githubRunId,
+        workflowName: githubWorkflowRuns.workflowName,
+        branch: githubWorkflowRuns.branch,
+        status: githubWorkflowRuns.status,
+        conclusion: githubWorkflowRuns.conclusion,
+        createdAt: githubWorkflowRuns.createdAtGithub,
+      })
+      .from(githubWorkflowRuns)
+      .where(eq(githubWorkflowRuns.repositoryId, repositoryId)),
+  ]);
+
+  const findings: AttentionFinding[] = [];
+
+  for (const pullRequest of pullRequests) {
+    const finding = evaluatePullRequest({ ...pullRequest, now });
+    if (finding) findings.push(finding);
+  }
+
+  for (const issue of issues) {
+    const finding = evaluateIssue({ ...issue, now });
+    if (finding) findings.push(finding);
+  }
+
+  findings.push(...evaluateWorkflows({ repositoryId, runs: workflowRuns }));
+
+  const desiredKeys = new Set(
+    findings.map((finding) => `${finding.ruleId}:${finding.resourceType}:${finding.resourceId}`),
+  );
+
+  await db.transaction(async (tx) => {
+    for (const finding of findings) {
+      await tx
+        .insert(attentionItems)
+        .values({
+          projectId: repository.projectId,
+          repositoryId,
+          ruleId: finding.ruleId,
+          resourceType: finding.resourceType,
+          resourceId: finding.resourceId,
+          severity: finding.severity,
+          status: "ACTIVE",
+          message: finding.message,
+          detectedAt: now,
+          resolvedAt: null,
+        })
+        .onConflictDoUpdate({
+          target: [attentionItems.ruleId, attentionItems.resourceType, attentionItems.resourceId],
+          set: {
+            projectId: repository.projectId,
+            repositoryId,
+            severity: finding.severity,
+            status: "ACTIVE",
+            message: finding.message,
+            resolvedAt: null,
+          },
+        });
+    }
+
+    const existing = await tx
+      .select({
+        id: attentionItems.id,
+        ruleId: attentionItems.ruleId,
+        resourceType: attentionItems.resourceType,
+        resourceId: attentionItems.resourceId,
+      })
+      .from(attentionItems)
+      .where(
+        and(
+          eq(attentionItems.repositoryId, repositoryId),
+          eq(attentionItems.status, "ACTIVE"),
+          inArray(attentionItems.ruleId, [...RULE_IDS]),
+        ),
+      );
+
+    for (const item of existing) {
+      const key = `${item.ruleId}:${item.resourceType}:${item.resourceId}`;
+      if (desiredKeys.has(key)) continue;
+
+      await tx
+        .update(attentionItems)
+        .set({ status: "RESOLVED", resolvedAt: now })
+        .where(eq(attentionItems.id, item.id));
+    }
+  });
+
+  return {
+    active: findings.length,
+    findings,
+    evaluatedAt: now,
+  };
+}

--- a/src/modules/attention/rules.ts
+++ b/src/modules/attention/rules.ts
@@ -1,0 +1,114 @@
+export type AttentionSeverity = "INFO" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type AttentionFinding = {
+  ruleId: "PR_WAITING_REVIEW" | "STALE_ISSUE" | "WORKFLOW_FAILED";
+  resourceType: "pull_request" | "issue" | "workflow";
+  resourceId: string;
+  severity: AttentionSeverity;
+  message: string;
+};
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+export function evaluatePullRequest(params: {
+  githubId: string;
+  number: number;
+  state: string;
+  draft: boolean;
+  createdAt: Date;
+  firstReviewAt: Date | null;
+  now: Date;
+}): AttentionFinding | null {
+  if (params.state !== "open" || params.draft || params.firstReviewAt) return null;
+
+  const ageMs = params.now.getTime() - params.createdAt.getTime();
+  if (ageMs < 48 * HOUR) return null;
+
+  const hours = Math.floor(ageMs / HOUR);
+  return {
+    ruleId: "PR_WAITING_REVIEW",
+    resourceType: "pull_request",
+    resourceId: params.githubId,
+    severity: ageMs >= 96 * HOUR ? "HIGH" : "MEDIUM",
+    message: `PR #${params.number} has been waiting for its first review for ${hours}h.`,
+  };
+}
+
+export function evaluateIssue(params: {
+  githubId: string;
+  number: number;
+  state: string;
+  lastActivityAt: Date;
+  now: Date;
+}): AttentionFinding | null {
+  if (params.state !== "open") return null;
+
+  const ageMs = params.now.getTime() - params.lastActivityAt.getTime();
+  if (ageMs < 5 * DAY) return null;
+
+  const days = Math.floor(ageMs / DAY);
+  const severity: AttentionSeverity = days >= 20 ? "HIGH" : days >= 10 ? "MEDIUM" : "LOW";
+
+  return {
+    ruleId: "STALE_ISSUE",
+    resourceType: "issue",
+    resourceId: params.githubId,
+    severity,
+    message: `Issue #${params.number} has had no activity for ${days} days.`,
+  };
+}
+
+export type WorkflowRunForAttention = {
+  githubRunId: string;
+  workflowName: string;
+  branch: string | null;
+  status: string;
+  conclusion: string | null;
+  createdAt: Date;
+};
+
+const FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "startup_failure"]);
+
+export function evaluateWorkflows(params: {
+  repositoryId: string;
+  runs: WorkflowRunForAttention[];
+}): AttentionFinding[] {
+  const groups = new Map<string, WorkflowRunForAttention[]>();
+
+  for (const run of params.runs) {
+    const key = `${run.workflowName}::${run.branch ?? ""}`;
+    const group = groups.get(key) ?? [];
+    group.push(run);
+    groups.set(key, group);
+  }
+
+  const findings: AttentionFinding[] = [];
+
+  for (const [key, runs] of groups) {
+    const ordered = [...runs].sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+    const latest = ordered[0];
+    if (!latest || latest.status !== "completed" || !latest.conclusion || !FAILURE_CONCLUSIONS.has(latest.conclusion)) {
+      continue;
+    }
+
+    let consecutiveFailures = 0;
+    for (const run of ordered) {
+      if (run.status === "completed" && run.conclusion && FAILURE_CONCLUSIONS.has(run.conclusion)) {
+        consecutiveFailures += 1;
+      } else {
+        break;
+      }
+    }
+
+    findings.push({
+      ruleId: "WORKFLOW_FAILED",
+      resourceType: "workflow",
+      resourceId: `${params.repositoryId}:${key}`,
+      severity: consecutiveFailures >= 3 ? "HIGH" : "MEDIUM",
+      message: `${latest.workflowName}${latest.branch ? ` on ${latest.branch}` : ""} has ${consecutiveFailures} consecutive failed run${consecutiveFailures === 1 ? "" : "s"}.`,
+    });
+  }
+
+  return findings;
+}

--- a/src/modules/sync/github-sync.ts
+++ b/src/modules/sync/github-sync.ts
@@ -10,6 +10,7 @@ import {
   projects,
   repositories,
 } from "@/db/schema";
+import { evaluateRepositoryAttention } from "@/modules/attention/engine";
 import { createInstallationToken } from "@/modules/github/app-api";
 import { decryptCredential } from "@/modules/github/credentials";
 import {
@@ -207,11 +208,14 @@ export async function syncGithubRepository(repositoryId: string, userId: string)
       .where(eq(repositories.id, connection.repositoryId));
   });
 
+  const attention = await evaluateRepositoryAttention(connection.repositoryId, now);
+
   return {
     issues: issues.length,
     pullRequests: pullRequests.length,
     reviews: reviewCount,
     workflowRuns: workflowRuns.length,
+    attention: attention.active,
     syncedAt: now,
   };
 }

--- a/tests/attention-rules.test.ts
+++ b/tests/attention-rules.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateIssue,
+  evaluatePullRequest,
+  evaluateWorkflows,
+} from "@/modules/attention/rules";
+
+const now = new Date("2026-09-02T20:00:00.000Z");
+const hoursAgo = (hours: number) => new Date(now.getTime() - hours * 60 * 60 * 1000);
+const daysAgo = (days: number) => new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+describe("Attention rules", () => {
+  it("does not flag a PR before 48 hours", () => {
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-1",
+        number: 1,
+        state: "open",
+        draft: false,
+        createdAt: hoursAgo(47),
+        firstReviewAt: null,
+        now,
+      }),
+    ).toBeNull();
+  });
+
+  it("flags an unreviewed PR at 48h and escalates at 96h", () => {
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-1",
+        number: 1,
+        state: "open",
+        draft: false,
+        createdAt: hoursAgo(48),
+        firstReviewAt: null,
+        now,
+      })?.severity,
+    ).toBe("MEDIUM");
+
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-1",
+        number: 1,
+        state: "open",
+        draft: false,
+        createdAt: hoursAgo(96),
+        firstReviewAt: null,
+        now,
+      })?.severity,
+    ).toBe("HIGH");
+  });
+
+  it("does not flag reviewed, draft or closed PRs", () => {
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-1",
+        number: 1,
+        state: "open",
+        draft: false,
+        createdAt: hoursAgo(120),
+        firstReviewAt: hoursAgo(2),
+        now,
+      }),
+    ).toBeNull();
+
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-2",
+        number: 2,
+        state: "open",
+        draft: true,
+        createdAt: hoursAgo(120),
+        firstReviewAt: null,
+        now,
+      }),
+    ).toBeNull();
+
+    expect(
+      evaluatePullRequest({
+        githubId: "pr-3",
+        number: 3,
+        state: "closed",
+        draft: false,
+        createdAt: hoursAgo(120),
+        firstReviewAt: null,
+        now,
+      }),
+    ).toBeNull();
+  });
+
+  it("flags stale issues at 5 days and escalates with age", () => {
+    expect(
+      evaluateIssue({
+        githubId: "issue-1",
+        number: 1,
+        state: "open",
+        lastActivityAt: daysAgo(5),
+        now,
+      })?.severity,
+    ).toBe("LOW");
+
+    expect(
+      evaluateIssue({
+        githubId: "issue-1",
+        number: 1,
+        state: "open",
+        lastActivityAt: daysAgo(10),
+        now,
+      })?.severity,
+    ).toBe("MEDIUM");
+
+    expect(
+      evaluateIssue({
+        githubId: "issue-1",
+        number: 1,
+        state: "open",
+        lastActivityAt: daysAgo(20),
+        now,
+      })?.severity,
+    ).toBe("HIGH");
+  });
+
+  it("only evaluates the latest workflow state and escalates consecutive failures", () => {
+    const findings = evaluateWorkflows({
+      repositoryId: "repo-1",
+      runs: [
+        {
+          githubRunId: "3",
+          workflowName: "CI",
+          branch: "main",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(1),
+        },
+        {
+          githubRunId: "2",
+          workflowName: "CI",
+          branch: "main",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(2),
+        },
+        {
+          githubRunId: "1",
+          workflowName: "CI",
+          branch: "main",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(3),
+        },
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("HIGH");
+    expect(findings[0]?.message).toContain("3 consecutive failed runs");
+  });
+
+  it("does not flag a workflow when the latest run recovered", () => {
+    expect(
+      evaluateWorkflows({
+        repositoryId: "repo-1",
+        runs: [
+          {
+            githubRunId: "2",
+            workflowName: "CI",
+            branch: "main",
+            status: "completed",
+            conclusion: "success",
+            createdAt: hoursAgo(1),
+          },
+          {
+            githubRunId: "1",
+            workflowName: "CI",
+            branch: "main",
+            status: "completed",
+            conclusion: "failure",
+            createdAt: hoursAgo(2),
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements #12.

Adds deterministic rules for unreviewed pull requests, stale issues and failed workflows; evaluates them after repository sync; persists/resolves AttentionItems idempotently; and surfaces current attention on the dashboard. Includes unit coverage for thresholds, escalation and workflow recovery.