### PR TITLE
feat(i18n): add PT-BR localization

### DIFF
--- a/src/app/api/locale/route.ts
+++ b/src/app/api/locale/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isLocale, localeCookieName } from "@/modules/i18n";
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const locale = formData.get("locale");
+  const returnToValue = formData.get("returnTo");
+  const returnTo =
+    typeof returnToValue === "string" && returnToValue.startsWith("/") && !returnToValue.startsWith("//")
+      ? returnToValue
+      : "/";
+
+  if (!isLocale(locale)) {
+    return NextResponse.redirect(new URL(returnTo, request.url), 303);
+  }
+
+  const response = NextResponse.redirect(new URL(returnTo, request.url), 303);
+  response.cookies.set(localeCookieName, locale, {
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+  });
+  return response;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { and, count, desc, eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
+import { LocaleSwitcher } from "@/components/locale-switcher";
 import { db } from "@/db";
 import {
   attentionItems,
@@ -11,10 +12,19 @@ import {
   repositories,
 } from "@/db/schema";
 import { getCurrentUser } from "@/modules/auth/current-user";
+import {
+  formatDateTime,
+  getLocale,
+  getMessages,
+  localizeAttentionMessage,
+  severityLabel,
+  visibilityLabel,
+} from "@/modules/i18n";
 
 export default async function DashboardPage() {
-  const user = await getCurrentUser();
+  const [user, locale] = await Promise.all([getCurrentUser(), getLocale()]);
   if (!user) redirect("/");
+  const t = getMessages(locale);
 
   const [appConfiguration] = await db
     .select({ id: githubAppConfigurations.id, slug: githubAppConfigurations.slug })
@@ -85,113 +95,126 @@ export default async function DashboardPage() {
           <span>DevBoard</span>
         </div>
         <div className="account-actions">
+          <LocaleSwitcher locale={locale} returnTo="/dashboard" />
           <span className="status-pill">@{user.username}</span>
           <form action="/api/auth/logout" method="post">
             <button className="secondary" type="submit">
-              Sign out
+              {t.signOut}
             </button>
           </form>
         </div>
       </nav>
 
       <section className="hero dashboard-hero">
-        <p className="eyebrow">GITHUB CONNECTION ACTIVE</p>
-        <h1>Welcome, {user.name ?? user.username}.</h1>
+        <p className="eyebrow">{t.githubConnectionActive}</p>
+        <h1>{t.welcome(user.name ?? user.username)}</h1>
         <p className="hero-copy">
           {hasSyncedData
-            ? "DevBoard is reading normalized engineering signals and converting them into deterministic attention."
+            ? t.syncedHero
             : repositoryCount > 0
-              ? "Your first repository is connected. Run the initial sync to import pull requests, issues, reviews and workflows."
-              : "Your DevBoard account is linked to GitHub. Connect the DevBoard GitHub App to start observing real repositories."}
+              ? t.repoConnectedHero
+              : t.githubLinkedHero}
         </p>
         <div className="hero-actions">
           {appConfiguration ? (
             <a className="primary" href="/api/github/app/install">
-              Connect repositories
+              {t.connectRepositories}
             </a>
           ) : (
             <a className="primary" href="/api/github/app/manifest">
-              Create DevBoard GitHub App
+              {t.createGithubApp}
             </a>
           )}
-          <span>
-            {appConfiguration
-              ? `GitHub App: ${appConfiguration.slug}`
-              : "One-time bootstrap. Permissions are preconfigured."}
-          </span>
+          <span>{appConfiguration ? t.githubApp(appConfiguration.slug) : t.bootstrapHint}</span>
         </div>
       </section>
 
-      <section className="signal-grid" aria-label="DevBoard repository signals">
+      <section
+        className="signal-grid"
+        aria-label={locale === "pt-BR" ? "Sinais dos repositórios" : "Repository signals"}
+      >
         <article className="signal-card">
-          <span>Repositories</span>
+          <span>{t.repositories}</span>
           <strong>{repositoryCount}</strong>
-          <p>{repositoryCount > 0 ? "Observed by DevBoard" : "No repository connected yet"}</p>
+          <p>{repositoryCount > 0 ? t.observedByDevboard : t.noRepoYet}</p>
         </article>
         <article className="signal-card">
-          <span>Pull requests</span>
+          <span>{t.pullRequests}</span>
           <strong>{pullRequestCount}</strong>
-          <p>{hasSyncedData ? "Normalized from GitHub" : "Waiting for initial sync"}</p>
+          <p>{hasSyncedData ? t.normalizedFromGithub : t.waitingInitialSync}</p>
         </article>
         <article className="signal-card">
-          <span>Needs attention</span>
+          <span>{t.needsAttention}</span>
           <strong>{hasSyncedData ? attentionCount : "--"}</strong>
           <p>
             {hasSyncedData
-              ? `${issueCount} issues · ${workflowRunCount} workflow runs observed`
-              : "Waiting for initial sync"}
+              ? t.observedIssuesWorkflows(issueCount, workflowRunCount)
+              : t.waitingInitialSync}
           </p>
         </article>
       </section>
 
       <section className="principle">
         <div>
-          <p className="eyebrow">{hasSyncedData ? "ATTENTION ENGINE" : "INITIAL SYNC"}</p>
-          <h2>{hasSyncedData ? "Know what needs attention." : "Import real engineering signals."}</h2>
+          <p className="eyebrow">{hasSyncedData ? t.attentionEngine : t.initialSync}</p>
+          <h2>{hasSyncedData ? t.knowAttention : t.importSignals}</h2>
         </div>
-        <p>
-          {hasSyncedData
-            ? "DevBoard currently evaluates explainable rules for pull requests waiting on review, stale issues and failed workflows."
-            : "Sync uses a short-lived GitHub App installation token. DevBoard never stores that token in PostgreSQL."}
-        </p>
+        <p>{hasSyncedData ? t.attentionRulesCopy : t.tokenCopy}</p>
       </section>
 
       {hasSyncedData ? (
-        <section className="repository-list" aria-label="Active attention items">
+        <section
+          className="repository-list"
+          aria-label={locale === "pt-BR" ? "Itens ativos de atenção" : "Active attention items"}
+        >
           {activeAttention.length > 0 ? (
             activeAttention.map((item) => (
               <article className="signal-card" key={item.id}>
-                <span>{item.severity} · {item.owner}/{item.name}</span>
-                <strong className="signal-word">{item.message}</strong>
-                <p>Detected: {item.detectedAt.toISOString()}</p>
+                <span>
+                  {severityLabel(locale, item.severity)} · {item.owner}/{item.name}
+                </span>
+                <strong className="signal-word">
+                  {localizeAttentionMessage(locale, item.message)}
+                </strong>
+                <p>
+                  {t.detected}: {formatDateTime(locale, item.detectedAt)}
+                </p>
               </article>
             ))
           ) : (
             <article className="signal-card">
-              <span>Attention</span>
-              <strong className="signal-word">No active signals.</strong>
-              <p>The current deterministic rules did not find anything requiring attention.</p>
+              <span>{t.attention}</span>
+              <strong className="signal-word">{t.noActiveSignals}</strong>
+              <p>{t.noActiveSignalsCopy}</p>
             </article>
           )}
         </section>
       ) : null}
 
       {connectedRepositories.length > 0 ? (
-        <section className="repository-list" aria-label="Connected repositories">
+        <section
+          className="repository-list"
+          aria-label={locale === "pt-BR" ? "Repositórios conectados" : "Connected repositories"}
+        >
           {connectedRepositories.map((repository) => (
             <article className="signal-card" key={repository.id}>
-              <span>{repository.visibility}</span>
+              <span>{visibilityLabel(locale, repository.visibility)}</span>
               <strong className="signal-word">
                 {repository.owner}/{repository.name}
               </strong>
-              <p>Default branch: {repository.defaultBranch}</p>
               <p>
-                Last sync: {repository.lastSyncedAt ? repository.lastSyncedAt.toISOString() : "never"}
+                {t.defaultBranch}: {repository.defaultBranch}
+              </p>
+              <p>
+                {t.lastSync}:{" "}
+                {repository.lastSyncedAt
+                  ? formatDateTime(locale, repository.lastSyncedAt)
+                  : t.never}
               </p>
               <form action="/api/github/sync" method="post">
                 <input name="repositoryId" type="hidden" value={repository.id} />
                 <button className="secondary" type="submit">
-                  {repository.lastSyncedAt ? "Sync again" : "Sync now"}
+                  {repository.lastSyncedAt ? t.syncAgain : t.syncNow}
                 </button>
               </form>
             </article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,6 +89,40 @@ a {
   gap: 10px;
 }
 
+.locale-switcher {
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(16, 18, 22, 0.7);
+}
+
+.locale-switcher form {
+  display: flex;
+}
+
+.locale-option {
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.locale-option.active {
+  background: var(--accent);
+  color: #11140a;
+}
+
+.locale-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .hero {
   max-width: 850px;
   padding: 112px 0 72px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getLocale } from "@/modules/i18n";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -6,9 +7,13 @@ export const metadata: Metadata = {
   description: "GitHub tracks the work. DevBoard tells you how it's going.",
 };
 
-export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+export default async function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const locale = await getLocale();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body>{children}</body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,15 @@
+import { LocaleSwitcher } from "@/components/locale-switcher";
 import { getCurrentUser } from "@/modules/auth/current-user";
-
-const signals = [
-  { label: "Project health", value: "--", caption: "Connect a repository to calculate" },
-  { label: "Needs attention", value: "--", caption: "No repository connected" },
-  { label: "Recent activity", value: "--", caption: "Waiting for real events" },
-];
+import { getLocale, getMessages } from "@/modules/i18n";
 
 export default async function Home() {
-  const user = await getCurrentUser();
+  const [user, locale] = await Promise.all([getCurrentUser(), getLocale()]);
+  const t = getMessages(locale);
+  const signals = [
+    { label: t.projectHealth, value: "--", caption: t.connectRepoCalculate },
+    { label: t.needsAttention, value: "--", caption: t.noRepositoryConnected },
+    { label: t.recentActivity, value: "--", caption: t.waitingRealEvents },
+  ];
 
   return (
     <main className="shell">
@@ -16,27 +18,23 @@ export default async function Home() {
           <span className="brand-mark">D</span>
           <span>DevBoard</span>
         </div>
-        <span className="status-pill">
-          {user ? `Signed in as @${user.username}` : "Private alpha"}
-        </span>
+        <div className="account-actions">
+          <LocaleSwitcher locale={locale} returnTo="/" />
+          <span className="status-pill">
+            {user ? t.signedInAs(user.username) : t.privateAlpha}
+          </span>
+        </div>
       </nav>
 
       <section className="hero">
-        <p className="eyebrow">SOFTWARE PROJECT OBSERVABILITY</p>
-        <h1>Know how your software is moving.</h1>
-        <p className="hero-copy">
-          GitHub tracks the work. DevBoard turns project activity into health,
-          attention signals and context you can understand in seconds.
-        </p>
+        <p className="eyebrow">{t.eyebrowHome}</p>
+        <h1>{t.homeTitle}</h1>
+        <p className="hero-copy">{t.homeCopy}</p>
         <div className="hero-actions">
           <a className="primary" href={user ? "/dashboard" : "/api/auth/github"}>
-            {user ? "Open dashboard" : "Continue with GitHub"}
+            {user ? t.openDashboard : t.continueGithub}
           </a>
-          <span>
-            {user
-              ? "Your GitHub identity is connected."
-              : "Read-only identity access for the first MVP."}
-          </span>
+          <span>{user ? t.identityConnected : t.readonlyIdentity}</span>
         </div>
       </section>
 
@@ -52,13 +50,10 @@ export default async function Home() {
 
       <section className="principle">
         <div>
-          <p className="eyebrow">PRODUCT PRINCIPLE</p>
-          <h2>What needs your attention?</h2>
+          <p className="eyebrow">{t.productPrinciple}</p>
+          <h2>{t.whatNeedsAttention}</h2>
         </div>
-        <p>
-          DevBoard does not replace GitHub Projects. It observes the development
-          flow, detects signals that matter, and explains how they affect project health.
-        </p>
+        <p>{t.principleCopy}</p>
       </section>
     </main>
   );

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -1,0 +1,21 @@
+import type { Locale } from "@/modules/i18n";
+
+export function LocaleSwitcher({ locale, returnTo }: { locale: Locale; returnTo: string }) {
+  return (
+    <div className="locale-switcher" aria-label="Language selector">
+      {(["pt-BR", "en"] as const).map((option) => (
+        <form action="/api/locale" method="post" key={option}>
+          <input type="hidden" name="locale" value={option} />
+          <input type="hidden" name="returnTo" value={returnTo} />
+          <button
+            type="submit"
+            className={`locale-option${locale === option ? " active" : ""}`}
+            aria-current={locale === option ? "true" : undefined}
+          >
+            {option === "pt-BR" ? "PT-BR" : "EN"}
+          </button>
+        </form>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/i18n/index.ts
+++ b/src/modules/i18n/index.ts
@@ -1,0 +1,257 @@
+import { cookies } from "next/headers";
+
+export const supportedLocales = ["pt-BR", "en"] as const;
+export type Locale = (typeof supportedLocales)[number];
+
+const LOCALE_COOKIE = "devboard_locale";
+
+export function isLocale(value: unknown): value is Locale {
+  return typeof value === "string" && supportedLocales.includes(value as Locale);
+}
+
+export async function getLocale(): Promise<Locale> {
+  const cookieStore = await cookies();
+  const value = cookieStore.get(LOCALE_COOKIE)?.value;
+  return isLocale(value) ? value : "pt-BR";
+}
+
+export const localeCookieName = LOCALE_COOKIE;
+
+type Messages = {
+  privateAlpha: string;
+  signedInAs: (username: string) => string;
+  eyebrowHome: string;
+  homeTitle: string;
+  homeCopy: string;
+  openDashboard: string;
+  continueGithub: string;
+  identityConnected: string;
+  readonlyIdentity: string;
+  projectHealth: string;
+  connectRepoCalculate: string;
+  needsAttention: string;
+  noRepositoryConnected: string;
+  recentActivity: string;
+  waitingRealEvents: string;
+  productPrinciple: string;
+  whatNeedsAttention: string;
+  principleCopy: string;
+  githubConnectionActive: string;
+  welcome: (name: string) => string;
+  syncedHero: string;
+  repoConnectedHero: string;
+  githubLinkedHero: string;
+  connectRepositories: string;
+  createGithubApp: string;
+  githubApp: (slug: string) => string;
+  bootstrapHint: string;
+  repositories: string;
+  observedByDevboard: string;
+  noRepoYet: string;
+  pullRequests: string;
+  normalizedFromGithub: string;
+  waitingInitialSync: string;
+  observedIssuesWorkflows: (issues: number, workflows: number) => string;
+  attentionEngine: string;
+  initialSync: string;
+  knowAttention: string;
+  importSignals: string;
+  attentionRulesCopy: string;
+  tokenCopy: string;
+  attention: string;
+  noActiveSignals: string;
+  noActiveSignalsCopy: string;
+  detected: string;
+  defaultBranch: string;
+  lastSync: string;
+  never: string;
+  syncAgain: string;
+  syncNow: string;
+  signOut: string;
+  public: string;
+  private: string;
+  internal: string;
+  language: string;
+};
+
+const dictionaries: Record<Locale, Messages> = {
+  "pt-BR": {
+    privateAlpha: "Alpha privado",
+    signedInAs: (username) => `Conectado como @${username}`,
+    eyebrowHome: "OBSERVABILIDADE DE PROJETOS DE SOFTWARE",
+    homeTitle: "Entenda como seu software está evoluindo.",
+    homeCopy:
+      "O GitHub acompanha o trabalho. O DevBoard transforma a atividade do projeto em saúde, sinais de atenção e contexto que você entende em segundos.",
+    openDashboard: "Abrir painel",
+    continueGithub: "Continuar com GitHub",
+    identityConnected: "Sua identidade do GitHub está conectada.",
+    readonlyIdentity: "Acesso de identidade somente leitura para o primeiro MVP.",
+    projectHealth: "Saúde do projeto",
+    connectRepoCalculate: "Conecte um repositório para calcular",
+    needsAttention: "Precisa de atenção",
+    noRepositoryConnected: "Nenhum repositório conectado",
+    recentActivity: "Atividade recente",
+    waitingRealEvents: "Aguardando eventos reais",
+    productPrinciple: "PRINCÍPIO DO PRODUTO",
+    whatNeedsAttention: "O que precisa da sua atenção?",
+    principleCopy:
+      "O DevBoard não substitui o GitHub Projects. Ele observa o fluxo de desenvolvimento, detecta sinais relevantes e explica como eles afetam a saúde do projeto.",
+    githubConnectionActive: "CONEXÃO COM GITHUB ATIVA",
+    welcome: (name) => `Bem-vindo, ${name}.`,
+    syncedHero:
+      "O DevBoard está lendo sinais normalizados de engenharia e convertendo-os em atenção determinística.",
+    repoConnectedHero:
+      "Seu primeiro repositório está conectado. Rode a sincronização inicial para importar pull requests, issues, reviews e workflows.",
+    githubLinkedHero:
+      "Sua conta do DevBoard está vinculada ao GitHub. Conecte o GitHub App do DevBoard para começar a observar repositórios reais.",
+    connectRepositories: "Conectar repositórios",
+    createGithubApp: "Criar GitHub App do DevBoard",
+    githubApp: (slug) => `GitHub App: ${slug}`,
+    bootstrapHint: "Configuração única. As permissões já estão pré-configuradas.",
+    repositories: "Repositórios",
+    observedByDevboard: "Observado pelo DevBoard",
+    noRepoYet: "Nenhum repositório conectado ainda",
+    pullRequests: "Pull requests",
+    normalizedFromGithub: "Normalizadas do GitHub",
+    waitingInitialSync: "Aguardando sincronização inicial",
+    observedIssuesWorkflows: (issues, workflows) => `${issues} issues · ${workflows} execuções de workflow observadas`,
+    attentionEngine: "MOTOR DE ATENÇÃO",
+    initialSync: "SINCRONIZAÇÃO INICIAL",
+    knowAttention: "Saiba o que precisa de atenção.",
+    importSignals: "Importe sinais reais de engenharia.",
+    attentionRulesCopy:
+      "O DevBoard avalia regras explicáveis para pull requests aguardando review, issues paradas e workflows com falha.",
+    tokenCopy:
+      "A sincronização usa um token temporário da instalação do GitHub App. O DevBoard nunca armazena esse token no PostgreSQL.",
+    attention: "Atenção",
+    noActiveSignals: "Nenhum sinal ativo.",
+    noActiveSignalsCopy: "As regras determinísticas atuais não encontraram nada que exija atenção.",
+    detected: "Detectado",
+    defaultBranch: "Branch padrão",
+    lastSync: "Última sincronização",
+    never: "nunca",
+    syncAgain: "Sincronizar novamente",
+    syncNow: "Sincronizar agora",
+    signOut: "Sair",
+    public: "público",
+    private: "privado",
+    internal: "interno",
+    language: "Idioma",
+  },
+  en: {
+    privateAlpha: "Private alpha",
+    signedInAs: (username) => `Signed in as @${username}`,
+    eyebrowHome: "SOFTWARE PROJECT OBSERVABILITY",
+    homeTitle: "Know how your software is moving.",
+    homeCopy:
+      "GitHub tracks the work. DevBoard turns project activity into health, attention signals and context you can understand in seconds.",
+    openDashboard: "Open dashboard",
+    continueGithub: "Continue with GitHub",
+    identityConnected: "Your GitHub identity is connected.",
+    readonlyIdentity: "Read-only identity access for the first MVP.",
+    projectHealth: "Project health",
+    connectRepoCalculate: "Connect a repository to calculate",
+    needsAttention: "Needs attention",
+    noRepositoryConnected: "No repository connected",
+    recentActivity: "Recent activity",
+    waitingRealEvents: "Waiting for real events",
+    productPrinciple: "PRODUCT PRINCIPLE",
+    whatNeedsAttention: "What needs your attention?",
+    principleCopy:
+      "DevBoard does not replace GitHub Projects. It observes the development flow, detects signals that matter, and explains how they affect project health.",
+    githubConnectionActive: "GITHUB CONNECTION ACTIVE",
+    welcome: (name) => `Welcome, ${name}.`,
+    syncedHero:
+      "DevBoard is reading normalized engineering signals and converting them into deterministic attention.",
+    repoConnectedHero:
+      "Your first repository is connected. Run the initial sync to import pull requests, issues, reviews and workflows.",
+    githubLinkedHero:
+      "Your DevBoard account is linked to GitHub. Connect the DevBoard GitHub App to start observing real repositories.",
+    connectRepositories: "Connect repositories",
+    createGithubApp: "Create DevBoard GitHub App",
+    githubApp: (slug) => `GitHub App: ${slug}`,
+    bootstrapHint: "One-time bootstrap. Permissions are preconfigured.",
+    repositories: "Repositories",
+    observedByDevboard: "Observed by DevBoard",
+    noRepoYet: "No repository connected yet",
+    pullRequests: "Pull requests",
+    normalizedFromGithub: "Normalized from GitHub",
+    waitingInitialSync: "Waiting for initial sync",
+    observedIssuesWorkflows: (issues, workflows) => `${issues} issues · ${workflows} workflow runs observed`,
+    attentionEngine: "ATTENTION ENGINE",
+    initialSync: "INITIAL SYNC",
+    knowAttention: "Know what needs attention.",
+    importSignals: "Import real engineering signals.",
+    attentionRulesCopy:
+      "DevBoard currently evaluates explainable rules for pull requests waiting on review, stale issues and failed workflows.",
+    tokenCopy:
+      "Sync uses a short-lived GitHub App installation token. DevBoard never stores that token in PostgreSQL.",
+    attention: "Attention",
+    noActiveSignals: "No active signals.",
+    noActiveSignalsCopy: "The current deterministic rules did not find anything requiring attention.",
+    detected: "Detected",
+    defaultBranch: "Default branch",
+    lastSync: "Last sync",
+    never: "never",
+    syncAgain: "Sync again",
+    syncNow: "Sync now",
+    signOut: "Sign out",
+    public: "public",
+    private: "private",
+    internal: "internal",
+    language: "Language",
+  },
+};
+
+export function getMessages(locale: Locale) {
+  return dictionaries[locale];
+}
+
+export function formatDateTime(locale: Locale, value: Date) {
+  return new Intl.DateTimeFormat(locale === "en" ? "en-US" : "pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(value);
+}
+
+export function visibilityLabel(locale: Locale, visibility: string) {
+  const messages = getMessages(locale);
+  if (visibility === "public") return messages.public;
+  if (visibility === "private") return messages.private;
+  if (visibility === "internal") return messages.internal;
+  return visibility;
+}
+
+export function severityLabel(locale: Locale, severity: string) {
+  if (locale === "en") return severity;
+  const labels: Record<string, string> = {
+    INFO: "INFORMAÇÃO",
+    LOW: "BAIXA",
+    MEDIUM: "MÉDIA",
+    HIGH: "ALTA",
+    CRITICAL: "CRÍTICA",
+  };
+  return labels[severity] ?? severity;
+}
+
+export function localizeAttentionMessage(locale: Locale, message: string) {
+  if (locale === "en") return message;
+
+  const pullRequest = message.match(/^PR #(\d+) has been waiting for its first review for (\d+)h\.$/);
+  if (pullRequest) {
+    return `A PR #${pullRequest[1]} está aguardando a primeira review há ${pullRequest[2]}h.`;
+  }
+
+  const issue = message.match(/^Issue #(\d+) has had no activity for (\d+) days\.$/);
+  if (issue) {
+    return `A issue #${issue[1]} está sem atividade há ${issue[2]} dias.`;
+  }
+
+  const workflow = message.match(/^(.*) has (\d+) consecutive failed runs?\.$/);
+  if (workflow) {
+    const count = Number(workflow[2]);
+    return `${workflow[1]} tem ${count} ${count === 1 ? "execução consecutiva com falha" : "execuções consecutivas com falha"}.`;
+  }
+
+  return message;
+}


### PR DESCRIPTION
Implements #14.

Adds pt-BR as the default locale, English as an alternate locale, a persistent PT-BR/EN switcher, localized home/dashboard copy, localized dates/visibility/severity, and localized presentation for the current deterministic attention messages. Internal rule IDs and database enums remain language-neutral.