### PR TITLE
feat(health): add Project Health dashboard and explanations

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
   repositories,
 } from "@/db/schema";
 import { getCurrentUser } from "@/modules/auth/current-user";
+import { listLatestProjectHealth } from "@/modules/health/dashboard";
 import {
   formatDateTime,
   getLocale,
@@ -19,7 +20,33 @@ import {
   localizeAttentionMessage,
   severityLabel,
   visibilityLabel,
+  type Locale,
 } from "@/modules/i18n";
+
+function healthStatusLabel(locale: Locale, status: string) {
+  if (locale === "en") {
+    if (status === "HEALTHY") return "Healthy";
+    if (status === "ATTENTION") return "Attention";
+    if (status === "AT_RISK") return "At risk";
+    return status;
+  }
+
+  if (status === "HEALTHY") return "Saudável";
+  if (status === "ATTENTION") return "Atenção";
+  if (status === "AT_RISK") return "Em risco";
+  return status;
+}
+
+function dimensionLabel(locale: Locale, dimension: string) {
+  if (locale === "en") return dimension;
+  const labels: Record<string, string> = {
+    DEVELOPMENT: "Desenvolvimento",
+    REVIEW: "Review",
+    DELIVERY: "Entrega",
+    PLANNING: "Planejamento",
+  };
+  return labels[dimension] ?? dimension;
+}
 
 export default async function DashboardPage() {
   const [user, locale] = await Promise.all([getCurrentUser(), getLocale()]);
@@ -46,40 +73,42 @@ export default async function DashboardPage() {
 
   const repositoryCount = connectedRepositories.length;
 
-  const [[pullRequestMetric], [issueMetric], [workflowMetric], activeAttention] = await Promise.all([
-    db
-      .select({ value: count() })
-      .from(githubPullRequests)
-      .innerJoin(repositories, eq(repositories.id, githubPullRequests.repositoryId))
-      .innerJoin(projects, eq(projects.id, repositories.projectId))
-      .where(eq(projects.userId, user.id)),
-    db
-      .select({ value: count() })
-      .from(githubIssues)
-      .innerJoin(repositories, eq(repositories.id, githubIssues.repositoryId))
-      .innerJoin(projects, eq(projects.id, repositories.projectId))
-      .where(eq(projects.userId, user.id)),
-    db
-      .select({ value: count() })
-      .from(githubWorkflowRuns)
-      .innerJoin(repositories, eq(repositories.id, githubWorkflowRuns.repositoryId))
-      .innerJoin(projects, eq(projects.id, repositories.projectId))
-      .where(eq(projects.userId, user.id)),
-    db
-      .select({
-        id: attentionItems.id,
-        severity: attentionItems.severity,
-        message: attentionItems.message,
-        detectedAt: attentionItems.detectedAt,
-        owner: repositories.owner,
-        name: repositories.name,
-      })
-      .from(attentionItems)
-      .innerJoin(repositories, eq(repositories.id, attentionItems.repositoryId))
-      .innerJoin(projects, eq(projects.id, repositories.projectId))
-      .where(and(eq(projects.userId, user.id), eq(attentionItems.status, "ACTIVE")))
-      .orderBy(desc(attentionItems.detectedAt)),
-  ]);
+  const [[pullRequestMetric], [issueMetric], [workflowMetric], activeAttention, latestHealth] =
+    await Promise.all([
+      db
+        .select({ value: count() })
+        .from(githubPullRequests)
+        .innerJoin(repositories, eq(repositories.id, githubPullRequests.repositoryId))
+        .innerJoin(projects, eq(projects.id, repositories.projectId))
+        .where(eq(projects.userId, user.id)),
+      db
+        .select({ value: count() })
+        .from(githubIssues)
+        .innerJoin(repositories, eq(repositories.id, githubIssues.repositoryId))
+        .innerJoin(projects, eq(projects.id, repositories.projectId))
+        .where(eq(projects.userId, user.id)),
+      db
+        .select({ value: count() })
+        .from(githubWorkflowRuns)
+        .innerJoin(repositories, eq(repositories.id, githubWorkflowRuns.repositoryId))
+        .innerJoin(projects, eq(projects.id, repositories.projectId))
+        .where(eq(projects.userId, user.id)),
+      db
+        .select({
+          id: attentionItems.id,
+          severity: attentionItems.severity,
+          message: attentionItems.message,
+          detectedAt: attentionItems.detectedAt,
+          owner: repositories.owner,
+          name: repositories.name,
+        })
+        .from(attentionItems)
+        .innerJoin(repositories, eq(repositories.id, attentionItems.repositoryId))
+        .innerJoin(projects, eq(projects.id, repositories.projectId))
+        .where(and(eq(projects.userId, user.id), eq(attentionItems.status, "ACTIVE")))
+        .orderBy(desc(attentionItems.detectedAt)),
+      listLatestProjectHealth(user.id),
+    ]);
 
   const pullRequestCount = pullRequestMetric?.value ?? 0;
   const issueCount = issueMetric?.value ?? 0;
@@ -156,6 +185,107 @@ export default async function DashboardPage() {
           </p>
         </article>
       </section>
+
+      {latestHealth.length > 0 ? (
+        <section className="health-section" aria-label={t.projectHealth}>
+          <div className="principle health-heading">
+            <div>
+              <p className="eyebrow">
+                {locale === "pt-BR" ? "SAÚDE DO PROJETO" : "PROJECT HEALTH"}
+              </p>
+              <h2>
+                {locale === "pt-BR"
+                  ? "Entenda por que o projeto está saudável ou em risco."
+                  : "Know why the project is healthy or at risk."}
+              </h2>
+            </div>
+            <p>
+              {locale === "pt-BR"
+                ? "O score é determinístico e explicável. Cada ponto perdido vem de um sinal concreto de engenharia, nunca de uma avaliação opaca de IA."
+                : "The score is deterministic and explainable. Every lost point comes from a concrete engineering signal, never from an opaque AI judgment."}
+            </p>
+          </div>
+
+          <div className="health-project-list">
+            {latestHealth.map((health) => (
+              <article className="health-project-card" key={health.snapshotId}>
+                <header className="health-project-header">
+                  <div>
+                    <span>{health.projectName}</span>
+                    <strong>
+                      {health.overallScore}
+                      <small>{healthStatusLabel(locale, health.status)}</small>
+                    </strong>
+                    <p>
+                      {locale === "pt-BR" ? "Calculado em" : "Calculated at"}:{" "}
+                      {formatDateTime(locale, health.createdAt)}
+                    </p>
+                  </div>
+                  <div className={`health-status health-status-${health.status.toLowerCase()}`}>
+                    {healthStatusLabel(locale, health.status)}
+                  </div>
+                </header>
+
+                <div className="health-dimensions">
+                  <div>
+                    <span>{locale === "pt-BR" ? "Desenvolvimento" : "Development"}</span>
+                    <strong>{health.developmentScore}</strong>
+                  </div>
+                  <div>
+                    <span>Review</span>
+                    <strong>{health.reviewScore}</strong>
+                  </div>
+                  <div>
+                    <span>{locale === "pt-BR" ? "Entrega" : "Delivery"}</span>
+                    <strong>{health.deliveryScore}</strong>
+                  </div>
+                  {health.planningScore !== null ? (
+                    <div>
+                      <span>{locale === "pt-BR" ? "Planejamento" : "Planning"}</span>
+                      <strong>{health.planningScore}</strong>
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="health-reasons">
+                  <div className="health-reasons-heading">
+                    <strong>{locale === "pt-BR" ? "Por quê?" : "Why?"}</strong>
+                    <span>
+                      {health.reasons.length === 0
+                        ? locale === "pt-BR"
+                          ? "Nenhuma penalidade ativa"
+                          : "No active penalties"
+                        : locale === "pt-BR"
+                          ? `${health.reasons.length} penalidade${health.reasons.length === 1 ? "" : "s"}`
+                          : `${health.reasons.length} ${health.reasons.length === 1 ? "penalty" : "penalties"}`}
+                    </span>
+                  </div>
+
+                  {health.reasons.length > 0 ? (
+                    <div className="health-reason-list">
+                      {health.reasons.map((reason) => (
+                        <div className="health-reason" key={`${reason.sourceId}:${reason.dimension}`}>
+                          <span className="health-impact">{reason.impact}</span>
+                          <div>
+                            <strong>{dimensionLabel(locale, reason.dimension)}</strong>
+                            <p>{localizeAttentionMessage(locale, reason.message)}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="health-clean-copy">
+                      {locale === "pt-BR"
+                        ? "Nenhum sinal ativo está reduzindo o Health Score neste snapshot."
+                        : "No active signal is reducing the Health Score in this snapshot."}
+                    </p>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="principle">
         <div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -267,6 +267,163 @@ h1 {
   line-height: 1.7;
 }
 
+.health-section {
+  margin-top: 18px;
+}
+
+.health-heading {
+  border-bottom: 0;
+}
+
+.health-project-list {
+  display: grid;
+  gap: 16px;
+}
+
+.health-project-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(16, 18, 22, 0.78);
+}
+
+.health-project-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+  border-bottom: 1px solid var(--border);
+}
+
+.health-project-header span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.health-project-header > div:first-child > strong {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 12px 0 8px;
+  font-size: clamp(54px, 8vw, 84px);
+  line-height: 0.95;
+  letter-spacing: -0.065em;
+}
+
+.health-project-header strong small {
+  color: var(--muted);
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+.health-project-header p {
+  margin: 0;
+  color: #686f7a;
+  font-size: 12px;
+}
+
+.health-status {
+  padding: 8px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-strong);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.health-status-healthy {
+  border-color: rgba(216, 255, 98, 0.35);
+  color: var(--accent);
+}
+
+.health-dimensions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border);
+}
+
+.health-dimensions > div {
+  min-height: 120px;
+  padding: 22px 28px;
+}
+
+.health-dimensions > div + div {
+  border-left: 1px solid var(--border);
+}
+
+.health-dimensions span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.health-dimensions strong {
+  display: block;
+  margin-top: 12px;
+  font-size: 34px;
+  letter-spacing: -0.05em;
+}
+
+.health-reasons {
+  padding: 26px 28px 28px;
+}
+
+.health-reasons-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.health-reasons-heading > strong {
+  font-size: 18px;
+}
+
+.health-reasons-heading > span {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.health-reason-list {
+  display: grid;
+  gap: 9px;
+}
+
+.health-reason {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #0c0e11;
+}
+
+.health-impact {
+  color: var(--accent);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.health-reason strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.health-reason p,
+.health-clean-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .planning-shell {
   width: min(1440px, calc(100% - 40px));
 }
@@ -552,24 +709,37 @@ h1 {
   }
 
   .hero-actions,
-  .principle {
+  .principle,
+  .health-project-header {
     align-items: flex-start;
     flex-direction: column;
   }
 
   .signal-grid,
   .principle,
-  .planning-header {
+  .planning-header,
+  .health-dimensions {
     grid-template-columns: 1fr;
   }
 
-  .signal-card + .signal-card {
+  .signal-card + .signal-card,
+  .health-dimensions > div + div {
     border-left: 0;
     border-top: 1px solid var(--border);
   }
 
   .principle {
     gap: 24px;
+  }
+
+  .health-project-header,
+  .health-reasons {
+    padding: 22px;
+  }
+
+  .health-reasons-heading {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .planning-header {

--- a/src/modules/health/dashboard.ts
+++ b/src/modules/health/dashboard.ts
@@ -1,0 +1,87 @@
+import { desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/db";
+import { healthReasons, healthSnapshots, projects } from "@/db/schema";
+
+export type HealthDashboardReason = {
+  dimension: string;
+  sourceType: string;
+  sourceId: string;
+  impact: number;
+  message: string;
+};
+
+export type ProjectHealthDashboard = {
+  snapshotId: string;
+  projectId: string;
+  projectName: string;
+  overallScore: number;
+  developmentScore: number;
+  reviewScore: number;
+  deliveryScore: number;
+  planningScore: number | null;
+  status: "HEALTHY" | "ATTENTION" | "AT_RISK";
+  createdAt: Date;
+  reasons: HealthDashboardReason[];
+};
+
+export async function listLatestProjectHealth(userId: string): Promise<ProjectHealthDashboard[]> {
+  const rows = await db
+    .select({
+      snapshotId: healthSnapshots.id,
+      projectId: healthSnapshots.projectId,
+      projectName: projects.name,
+      overallScore: healthSnapshots.overallScore,
+      developmentScore: healthSnapshots.developmentScore,
+      reviewScore: healthSnapshots.reviewScore,
+      deliveryScore: healthSnapshots.deliveryScore,
+      planningScore: healthSnapshots.planningScore,
+      status: healthSnapshots.status,
+      createdAt: healthSnapshots.createdAt,
+    })
+    .from(healthSnapshots)
+    .innerJoin(projects, eq(projects.id, healthSnapshots.projectId))
+    .where(eq(projects.userId, userId))
+    .orderBy(desc(healthSnapshots.createdAt))
+    .limit(100);
+
+  const latestByProject = new Map<string, (typeof rows)[number]>();
+  for (const row of rows) {
+    if (!latestByProject.has(row.projectId)) latestByProject.set(row.projectId, row);
+  }
+
+  const latest = [...latestByProject.values()];
+  if (latest.length === 0) return [];
+
+  const snapshotIds = latest.map((item) => item.snapshotId);
+  const reasons = await db
+    .select({
+      healthSnapshotId: healthReasons.healthSnapshotId,
+      dimension: healthReasons.dimension,
+      sourceType: healthReasons.sourceType,
+      sourceId: healthReasons.sourceId,
+      impact: healthReasons.impact,
+      message: healthReasons.message,
+    })
+    .from(healthReasons)
+    .where(inArray(healthReasons.healthSnapshotId, snapshotIds));
+
+  const reasonsBySnapshot = new Map<string, HealthDashboardReason[]>();
+  for (const reason of reasons) {
+    const items = reasonsBySnapshot.get(reason.healthSnapshotId) ?? [];
+    items.push({
+      dimension: reason.dimension,
+      sourceType: reason.sourceType,
+      sourceId: reason.sourceId,
+      impact: reason.impact,
+      message: reason.message,
+    });
+    reasonsBySnapshot.set(reason.healthSnapshotId, items);
+  }
+
+  return latest.map((item) => ({
+    ...item,
+    reasons: (reasonsBySnapshot.get(item.snapshotId) ?? []).sort(
+      (left, right) => left.impact - right.impact,
+    ),
+  }));
+}


### PR DESCRIPTION
Implements #19.

Surfaces the latest explainable Project Health snapshot on the dashboard with overall score/status, Development/Review/Delivery/Planning dimensions, snapshot timestamp and concrete penalty reasons. Supports PT-BR and EN presentation while reusing normalized Attention messages. Adds a small health dashboard query layer that returns only the latest snapshot per project.