### PR TITLE
feat(health): complete dashboard trend and source links

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -249,6 +249,28 @@ export default async function DashboardPage() {
 
                 <div className="health-reasons">
                   <div className="health-reasons-heading">
+                    <strong>{locale === "pt-BR" ? "Tendência recente" : "Recent trend"}</strong>
+                    <span>
+                      {locale === "pt-BR"
+                        ? `${health.trend.length} snapshot${health.trend.length === 1 ? "" : "s"}`
+                        : `${health.trend.length} snapshot${health.trend.length === 1 ? "" : "s"}`}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                    {health.trend.map((point, index) => (
+                      <span
+                        className="status-pill"
+                        key={`${point.createdAt.toISOString()}:${index}`}
+                        title={formatDateTime(locale, point.createdAt)}
+                      >
+                        {point.score} · {healthStatusLabel(locale, point.status)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="health-reasons" style={{ borderTop: "1px solid var(--border)" }}>
+                  <div className="health-reasons-heading">
                     <strong>{locale === "pt-BR" ? "Por quê?" : "Why?"}</strong>
                     <span>
                       {health.reasons.length === 0
@@ -269,6 +291,22 @@ export default async function DashboardPage() {
                           <div>
                             <strong>{dimensionLabel(locale, reason.dimension)}</strong>
                             <p>{localizeAttentionMessage(locale, reason.message)}</p>
+                            {reason.url ? (
+                              <a
+                                href={reason.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{
+                                  display: "inline-block",
+                                  marginTop: 8,
+                                  color: "var(--accent)",
+                                  fontSize: 12,
+                                  textDecoration: "none",
+                                }}
+                              >
+                                {locale === "pt-BR" ? "Abrir sinal no GitHub →" : "Open signal on GitHub →"}
+                              </a>
+                            ) : null}
                           </div>
                         </div>
                       ))}

--- a/src/modules/health/dashboard.ts
+++ b/src/modules/health/dashboard.ts
@@ -1,6 +1,14 @@
 import { desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/db";
-import { healthReasons, healthSnapshots, projects } from "@/db/schema";
+import {
+  attentionItems,
+  githubIssues,
+  githubPullRequests,
+  healthReasons,
+  healthSnapshots,
+  projects,
+  repositories,
+} from "@/db/schema";
 
 export type HealthDashboardReason = {
   dimension: string;
@@ -8,6 +16,13 @@ export type HealthDashboardReason = {
   sourceId: string;
   impact: number;
   message: string;
+  url: string | null;
+};
+
+export type HealthTrendPoint = {
+  score: number;
+  status: "HEALTHY" | "ATTENTION" | "AT_RISK";
+  createdAt: Date;
 };
 
 export type ProjectHealthDashboard = {
@@ -22,6 +37,7 @@ export type ProjectHealthDashboard = {
   status: "HEALTHY" | "ATTENTION" | "AT_RISK";
   createdAt: Date;
   reasons: HealthDashboardReason[];
+  trend: HealthTrendPoint[];
 };
 
 export async function listLatestProjectHealth(userId: string): Promise<ProjectHealthDashboard[]> {
@@ -44,16 +60,18 @@ export async function listLatestProjectHealth(userId: string): Promise<ProjectHe
     .orderBy(desc(healthSnapshots.createdAt))
     .limit(100);
 
-  const latestByProject = new Map<string, (typeof rows)[number]>();
+  const snapshotsByProject = new Map<string, (typeof rows)[number][]>();
   for (const row of rows) {
-    if (!latestByProject.has(row.projectId)) latestByProject.set(row.projectId, row);
+    const items = snapshotsByProject.get(row.projectId) ?? [];
+    if (items.length < 6) items.push(row);
+    snapshotsByProject.set(row.projectId, items);
   }
 
-  const latest = [...latestByProject.values()];
+  const latest = [...snapshotsByProject.values()].map((items) => items[0]).filter(Boolean);
   if (latest.length === 0) return [];
 
   const snapshotIds = latest.map((item) => item.snapshotId);
-  const reasons = await db
+  const reasonRows = await db
     .select({
       healthSnapshotId: healthReasons.healthSnapshotId,
       dimension: healthReasons.dimension,
@@ -65,8 +83,83 @@ export async function listLatestProjectHealth(userId: string): Promise<ProjectHe
     .from(healthReasons)
     .where(inArray(healthReasons.healthSnapshotId, snapshotIds));
 
+  const attentionIds = [...new Set(reasonRows.map((reason) => reason.sourceId))];
+  const attentionRows = attentionIds.length
+    ? await db
+        .select({
+          id: attentionItems.id,
+          repositoryId: attentionItems.repositoryId,
+          resourceType: attentionItems.resourceType,
+          resourceId: attentionItems.resourceId,
+        })
+        .from(attentionItems)
+        .where(inArray(attentionItems.id, attentionIds))
+    : [];
+
+  const attentionById = new Map(attentionRows.map((item) => [item.id, item]));
+  const repositoryIds = [
+    ...new Set(
+      attentionRows
+        .map((item) => item.repositoryId)
+        .filter((repositoryId): repositoryId is string => Boolean(repositoryId)),
+    ),
+  ];
+  const repositoryRows = repositoryIds.length
+    ? await db
+        .select({ id: repositories.id, owner: repositories.owner, name: repositories.name })
+        .from(repositories)
+        .where(inArray(repositories.id, repositoryIds))
+    : [];
+  const repositoryById = new Map(repositoryRows.map((repository) => [repository.id, repository]));
+
+  const pullRequestIds = attentionRows
+    .filter((item) => item.resourceType === "pull_request")
+    .map((item) => item.resourceId);
+  const issueIds = attentionRows
+    .filter((item) => item.resourceType === "issue")
+    .map((item) => item.resourceId);
+
+  const [pullRequestRows, issueRows] = await Promise.all([
+    pullRequestIds.length
+      ? db
+          .select({ githubId: githubPullRequests.githubPullRequestId, number: githubPullRequests.number })
+          .from(githubPullRequests)
+          .where(inArray(githubPullRequests.githubPullRequestId, pullRequestIds))
+      : Promise.resolve([]),
+    issueIds.length
+      ? db
+          .select({ githubId: githubIssues.githubIssueId, number: githubIssues.number })
+          .from(githubIssues)
+          .where(inArray(githubIssues.githubIssueId, issueIds))
+      : Promise.resolve([]),
+  ]);
+
+  const pullNumberByGithubId = new Map(pullRequestRows.map((item) => [item.githubId, item.number]));
+  const issueNumberByGithubId = new Map(issueRows.map((item) => [item.githubId, item.number]));
+
+  function sourceUrl(sourceId: string) {
+    const attention = attentionById.get(sourceId);
+    if (!attention?.repositoryId) return null;
+    const repository = repositoryById.get(attention.repositoryId);
+    if (!repository) return null;
+    const base = `https://github.com/${repository.owner}/${repository.name}`;
+
+    if (attention.resourceType === "pull_request") {
+      const number = pullNumberByGithubId.get(attention.resourceId);
+      return number ? `${base}/pull/${number}` : base;
+    }
+
+    if (attention.resourceType === "issue") {
+      const number = issueNumberByGithubId.get(attention.resourceId);
+      return number ? `${base}/issues/${number}` : base;
+    }
+
+    if (attention.resourceType === "workflow") return `${base}/actions`;
+    return base;
+  }
+
   const reasonsBySnapshot = new Map<string, HealthDashboardReason[]>();
-  for (const reason of reasons) {
+  for (const reason of reasonRows) {
     const items = reasonsBySnapshot.get(reason.healthSnapshotId) ?? [];
     items.push({
       dimension: reason.dimension,
@@ -74,6 +167,7 @@ export async function listLatestProjectHealth(userId: string): Promise<ProjectHe
       sourceId: reason.sourceId,
       impact: reason.impact,
       message: reason.message,
+      url: sourceUrl(reason.sourceId),
     });
     reasonsBySnapshot.set(reason.healthSnapshotId, items);
   }
@@ -83,5 +177,12 @@ export async function listLatestProjectHealth(userId: string): Promise<ProjectHe
     reasons: (reasonsBySnapshot.get(item.snapshotId) ?? []).sort(
       (left, right) => left.impact - right.impact,
     ),
+    trend: [...(snapshotsByProject.get(item.projectId) ?? [])]
+      .reverse()
+      .map((snapshot) => ({
+        score: snapshot.overallScore,
+        status: snapshot.status,
+        createdAt: snapshot.createdAt,
+      })),
   }));
 }


### PR DESCRIPTION
Completes #19.

Adds recent Health trend from persisted snapshots and links each explainable penalty back to its underlying GitHub signal when possible: PRs open their pull request, issues open their issue, and workflow penalties open Actions. Keeps PT-BR/EN behavior and the existing read-only observability model.