### PR TITLE
fix(attention): ignore obsolete workflow branch failures

### DIFF
--- a/src/modules/attention/engine.ts
+++ b/src/modules/attention/engine.ts
@@ -16,9 +16,16 @@ import {
 
 const RULE_IDS = ["PR_WAITING_REVIEW", "STALE_ISSUE", "WORKFLOW_FAILED"] as const;
 
-export async function evaluateRepositoryAttention(repositoryId: string, now = new Date()) {
+export async function evaluateRepositoryAttention(
+  repositoryId: string,
+  now = new Date(),
+  relevantWorkflowBranches?: Iterable<string>,
+) {
   const [repository] = await db
-    .select({ projectId: repositories.projectId })
+    .select({
+      projectId: repositories.projectId,
+      defaultBranch: repositories.defaultBranch,
+    })
     .from(repositories)
     .where(eq(repositories.id, repositoryId))
     .limit(1);
@@ -71,7 +78,13 @@ export async function evaluateRepositoryAttention(repositoryId: string, now = ne
     if (finding) findings.push(finding);
   }
 
-  findings.push(...evaluateWorkflows({ repositoryId, runs: workflowRuns }));
+  findings.push(
+    ...evaluateWorkflows({
+      repositoryId,
+      runs: workflowRuns,
+      relevantBranches: relevantWorkflowBranches ?? [repository.defaultBranch],
+    }),
+  );
 
   const desiredKeys = new Set(
     findings.map((finding) => `${finding.ruleId}:${finding.resourceType}:${finding.resourceId}`),

--- a/src/modules/attention/rules.ts
+++ b/src/modules/attention/rules.ts
@@ -73,10 +73,16 @@ const FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "start
 export function evaluateWorkflows(params: {
   repositoryId: string;
   runs: WorkflowRunForAttention[];
+  relevantBranches?: Iterable<string>;
 }): AttentionFinding[] {
+  const relevantBranches = params.relevantBranches
+    ? new Set(params.relevantBranches)
+    : null;
   const groups = new Map<string, WorkflowRunForAttention[]>();
 
   for (const run of params.runs) {
+    if (relevantBranches && (!run.branch || !relevantBranches.has(run.branch))) continue;
+
     const key = `${run.workflowName}::${run.branch ?? ""}`;
     const group = groups.get(key) ?? [];
     group.push(run);
@@ -88,13 +94,22 @@ export function evaluateWorkflows(params: {
   for (const [key, runs] of groups) {
     const ordered = [...runs].sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
     const latest = ordered[0];
-    if (!latest || latest.status !== "completed" || !latest.conclusion || !FAILURE_CONCLUSIONS.has(latest.conclusion)) {
+    if (
+      !latest ||
+      latest.status !== "completed" ||
+      !latest.conclusion ||
+      !FAILURE_CONCLUSIONS.has(latest.conclusion)
+    ) {
       continue;
     }
 
     let consecutiveFailures = 0;
     for (const run of ordered) {
-      if (run.status === "completed" && run.conclusion && FAILURE_CONCLUSIONS.has(run.conclusion)) {
+      if (
+        run.status === "completed" &&
+        run.conclusion &&
+        FAILURE_CONCLUSIONS.has(run.conclusion)
+      ) {
         consecutiveFailures += 1;
       } else {
         break;

--- a/src/modules/github/resources-api.ts
+++ b/src/modules/github/resources-api.ts
@@ -54,6 +54,7 @@ export type GithubPullRequestResource = {
   state: string;
   draft: boolean | null;
   user: { id: number } | null;
+  head: { ref: string } | null;
   created_at: string;
   updated_at: string;
   closed_at: string | null;

--- a/src/modules/sync/github-sync.ts
+++ b/src/modules/sync/github-sync.ts
@@ -57,6 +57,7 @@ export async function syncGithubRepository(repositoryId: string, userId: string)
       projectId: repositories.projectId,
       owner: repositories.owner,
       name: repositories.name,
+      defaultBranch: repositories.defaultBranch,
       installationId: githubInstallations.githubInstallationId,
       appId: githubAppConfigurations.githubAppId,
       privateKeyEncrypted: githubAppConfigurations.privateKeyEncrypted,
@@ -95,6 +96,13 @@ export async function syncGithubRepository(repositoryId: string, userId: string)
     connection.name,
     pullRequests.map((pullRequest) => pullRequest.number),
   );
+
+  const relevantWorkflowBranches = new Set<string>([connection.defaultBranch]);
+  for (const pullRequest of pullRequests) {
+    if (pullRequest.state === "open" && pullRequest.head?.ref) {
+      relevantWorkflowBranches.add(pullRequest.head.ref);
+    }
+  }
 
   const now = new Date();
   let reviewCount = 0;
@@ -210,7 +218,11 @@ export async function syncGithubRepository(repositoryId: string, userId: string)
       .where(eq(repositories.id, connection.repositoryId));
   });
 
-  const attention = await evaluateRepositoryAttention(connection.repositoryId, now);
+  const attention = await evaluateRepositoryAttention(
+    connection.repositoryId,
+    now,
+    relevantWorkflowBranches,
+  );
   const health = await recalculateProjectHealth(connection.projectId, now);
 
   return {

--- a/tests/attention-rules.test.ts
+++ b/tests/attention-rules.test.ts
@@ -181,4 +181,61 @@ describe("Attention rules", () => {
       }),
     ).toEqual([]);
   });
+
+  it("ignores failures from obsolete branches outside the current workflow context", () => {
+    expect(
+      evaluateWorkflows({
+        repositoryId: "repo-1",
+        relevantBranches: ["main"],
+        runs: [
+          {
+            githubRunId: "old-1",
+            workflowName: "CI",
+            branch: "feat/obsolete",
+            status: "completed",
+            conclusion: "failure",
+            createdAt: hoursAgo(1),
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps failures on the default branch and branches with open pull requests", () => {
+    const findings = evaluateWorkflows({
+      repositoryId: "repo-1",
+      relevantBranches: ["main", "feat/live-pr"],
+      runs: [
+        {
+          githubRunId: "main-1",
+          workflowName: "CI",
+          branch: "main",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(1),
+        },
+        {
+          githubRunId: "pr-1",
+          workflowName: "CI",
+          branch: "feat/live-pr",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(1),
+        },
+        {
+          githubRunId: "old-1",
+          workflowName: "CI",
+          branch: "feat/obsolete",
+          status: "completed",
+          conclusion: "failure",
+          createdAt: hoursAgo(1),
+        },
+      ],
+    });
+
+    expect(findings).toHaveLength(2);
+    expect(findings.map((finding) => finding.message).join(" ")).toContain("on main");
+    expect(findings.map((finding) => finding.message).join(" ")).toContain("on feat/live-pr");
+    expect(findings.map((finding) => finding.message).join(" ")).not.toContain("feat/obsolete");
+  });
 });


### PR DESCRIPTION
Fixes #28.

Uses the repository default branch plus branches from currently open pull requests as the workflow relevance context during sync. Workflow failures from obsolete feature branches are ignored and any existing Attention items for them are resolved by the normal reconciliation behavior. Includes regression coverage for obsolete branches and relevant default/open-PR branches.