### PR TITLE
feat(attention): evaluate time-based rules on a schedule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ DATABASE_URL=postgresql://user:password@localhost:5432/devboard
 GITHUB_APP_ID=
 GITHUB_PRIVATE_KEY=
 GITHUB_WEBHOOK_SECRET=
+
+# Scheduled Attention evaluation (Vercel Cron)
+CRON_SECRET=

--- a/docs/SCHEDULED_ATTENTION.md
+++ b/docs/SCHEDULED_ATTENTION.md
@@ -1,0 +1,58 @@
+# Scheduled Attention evaluation
+
+Some Attention rules become true only because time passes. GitHub does not emit a webhook exactly when a pull request reaches 48 hours without review or when an issue reaches the stale threshold.
+
+DevBoard therefore runs a scheduled, deterministic evaluation of time-based rules.
+
+## Current rules
+
+- `PR_WAITING_REVIEW`: open, non-draft pull request without a first review after 48 hours; severity increases after 96 hours.
+- `STALE_ISSUE`: open issue with no activity for 5 days; severity increases with age.
+
+Workflow failures are intentionally not reconciled by this scheduled pass. Workflow state is handled by sync/webhook processing so the time evaluator cannot accidentally resolve a valid workflow alert for an active pull-request branch.
+
+## Schedule
+
+The production Vercel configuration calls:
+
+```text
+GET /api/cron/attention
+```
+
+once per day at `09:00 UTC`.
+
+The daily frequency is deliberate because the current deployment uses the Vercel Hobby plan, which only supports daily native cron schedules. A threshold can therefore become visible on the next daily evaluation rather than at the exact minute it is crossed.
+
+If the project later moves to a plan or scheduler that supports higher frequency, the route and engine can be reused without changing the rule model.
+
+## Security
+
+Set a strong production environment variable:
+
+```text
+CRON_SECRET=<random secret of at least 16 characters>
+```
+
+Vercel sends it as:
+
+```text
+Authorization: Bearer <CRON_SECRET>
+```
+
+Requests without the exact bearer secret receive `401` and do not run the evaluator.
+
+## Execution model
+
+For each active repository connected through an active GitHub App installation, the scheduled runner:
+
+1. evaluates only time-based Attention rules;
+2. upserts matching Attention items using the existing natural rule/resource uniqueness;
+3. resolves time-based items whose conditions no longer match;
+4. recalculates Project Health for affected projects;
+5. emits safe structured log events with repository/project IDs and aggregate counts.
+
+The operation is idempotent. Re-running it does not create duplicate Attention items.
+
+## Failure behavior
+
+Repository failures are isolated so one repository does not prevent the remaining repositories from being evaluated. Health recalculation failures are isolated per project. A partial failure returns HTTP `500` and is visible in runtime logs; successful runs return HTTP `200` with aggregate counters.

--- a/src/app/api/cron/attention/route.ts
+++ b/src/app/api/cron/attention/route.ts
@@ -1,0 +1,35 @@
+import { isCronRequestAuthorized, runScheduledAttentionEvaluation } from "@/modules/attention/scheduled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  if (!isCronRequestAuthorized(request.headers.get("authorization"), process.env.CRON_SECRET)) {
+    return Response.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runScheduledAttentionEvaluation();
+    const ok = result.repositoryFailures === 0 && result.healthFailures === 0;
+
+    return Response.json(
+      {
+        ok,
+        repositoriesDiscovered: result.repositoriesDiscovered,
+        repositoriesEvaluated: result.repositoriesEvaluated,
+        repositoryFailures: result.repositoryFailures,
+        activeTimeFindings: result.activeTimeFindings,
+        projectsRecalculated: result.projectsRecalculated,
+        healthFailures: result.healthFailures,
+        durationMs: result.durationMs,
+        completedAt: result.completedAt.toISOString(),
+      },
+      { status: ok ? 200 : 500 },
+    );
+  } catch (error) {
+    console.error("scheduled_attention_run_failed", {
+      message: error instanceof Error ? error.message : "unknown error",
+    });
+    return Response.json({ ok: false, error: "Scheduled evaluation failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/attention/route.ts
+++ b/src/app/api/cron/attention/route.ts
@@ -1,4 +1,5 @@
-import { isCronRequestAuthorized, runScheduledAttentionEvaluation } from "@/modules/attention/scheduled";
+import { isCronRequestAuthorized } from "@/modules/attention/cron-auth";
+import { runScheduledAttentionEvaluation } from "@/modules/attention/scheduled";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,7 @@ const serverEnvSchema = z.object({
   GITHUB_APP_ID: z.string().optional(),
   GITHUB_PRIVATE_KEY: z.string().optional(),
   GITHUB_WEBHOOK_SECRET: z.string().optional(),
+  CRON_SECRET: z.string().min(16).optional(),
 });
 
 export function getServerEnv() {

--- a/src/modules/attention/cron-auth.ts
+++ b/src/modules/attention/cron-auth.ts
@@ -1,0 +1,3 @@
+export function isCronRequestAuthorized(authorization: string | null, secret: string | undefined) {
+  return Boolean(secret && authorization === `Bearer ${secret}`);
+}

--- a/src/modules/attention/engine.ts
+++ b/src/modules/attention/engine.ts
@@ -14,13 +14,15 @@ import {
   type AttentionFinding,
 } from "@/modules/attention/rules";
 
-const RULE_IDS = ["PR_WAITING_REVIEW", "STALE_ISSUE", "WORKFLOW_FAILED"] as const;
+const TIME_RULE_IDS = ["PR_WAITING_REVIEW", "STALE_ISSUE"] as const;
+const RULE_IDS = [...TIME_RULE_IDS, "WORKFLOW_FAILED"] as const;
 
-export async function evaluateRepositoryAttention(
-  repositoryId: string,
-  now = new Date(),
-  relevantWorkflowBranches?: Iterable<string>,
-) {
+type RepositoryContext = {
+  projectId: string;
+  defaultBranch: string;
+};
+
+async function loadRepositoryContext(repositoryId: string): Promise<RepositoryContext> {
   const [repository] = await db
     .select({
       projectId: repositories.projectId,
@@ -31,8 +33,11 @@ export async function evaluateRepositoryAttention(
     .limit(1);
 
   if (!repository) throw new Error("Repository not found for attention evaluation");
+  return repository;
+}
 
-  const [pullRequests, issues, workflowRuns] = await Promise.all([
+async function loadTimeBasedResources(repositoryId: string) {
+  return Promise.all([
     db
       .select({
         githubId: githubPullRequests.githubPullRequestId,
@@ -53,19 +58,14 @@ export async function evaluateRepositoryAttention(
       })
       .from(githubIssues)
       .where(eq(githubIssues.repositoryId, repositoryId)),
-    db
-      .select({
-        githubRunId: githubWorkflowRuns.githubRunId,
-        workflowName: githubWorkflowRuns.workflowName,
-        branch: githubWorkflowRuns.branch,
-        status: githubWorkflowRuns.status,
-        conclusion: githubWorkflowRuns.conclusion,
-        createdAt: githubWorkflowRuns.createdAtGithub,
-      })
-      .from(githubWorkflowRuns)
-      .where(eq(githubWorkflowRuns.repositoryId, repositoryId)),
   ]);
+}
 
+function evaluateTimeBasedResources(
+  pullRequests: Awaited<ReturnType<typeof loadTimeBasedResources>>[0],
+  issues: Awaited<ReturnType<typeof loadTimeBasedResources>>[1],
+  now: Date,
+) {
   const findings: AttentionFinding[] = [];
 
   for (const pullRequest of pullRequests) {
@@ -78,39 +78,43 @@ export async function evaluateRepositoryAttention(
     if (finding) findings.push(finding);
   }
 
-  findings.push(
-    ...evaluateWorkflows({
-      repositoryId,
-      runs: workflowRuns,
-      relevantBranches: relevantWorkflowBranches ?? [repository.defaultBranch],
-    }),
-  );
+  return findings;
+}
 
+async function reconcileRepositoryFindings(params: {
+  repositoryId: string;
+  projectId: string;
+  findings: AttentionFinding[];
+  ruleIds: readonly string[];
+  now: Date;
+}) {
   const desiredKeys = new Set(
-    findings.map((finding) => `${finding.ruleId}:${finding.resourceType}:${finding.resourceId}`),
+    params.findings.map(
+      (finding) => `${finding.ruleId}:${finding.resourceType}:${finding.resourceId}`,
+    ),
   );
 
   await db.transaction(async (tx) => {
-    for (const finding of findings) {
+    for (const finding of params.findings) {
       await tx
         .insert(attentionItems)
         .values({
-          projectId: repository.projectId,
-          repositoryId,
+          projectId: params.projectId,
+          repositoryId: params.repositoryId,
           ruleId: finding.ruleId,
           resourceType: finding.resourceType,
           resourceId: finding.resourceId,
           severity: finding.severity,
           status: "ACTIVE",
           message: finding.message,
-          detectedAt: now,
+          detectedAt: params.now,
           resolvedAt: null,
         })
         .onConflictDoUpdate({
           target: [attentionItems.ruleId, attentionItems.resourceType, attentionItems.resourceId],
           set: {
-            projectId: repository.projectId,
-            repositoryId,
+            projectId: params.projectId,
+            repositoryId: params.repositoryId,
             severity: finding.severity,
             status: "ACTIVE",
             message: finding.message,
@@ -129,9 +133,9 @@ export async function evaluateRepositoryAttention(
       .from(attentionItems)
       .where(
         and(
-          eq(attentionItems.repositoryId, repositoryId),
+          eq(attentionItems.repositoryId, params.repositoryId),
           eq(attentionItems.status, "ACTIVE"),
-          inArray(attentionItems.ruleId, [...RULE_IDS]),
+          inArray(attentionItems.ruleId, [...params.ruleIds]),
         ),
       );
 
@@ -141,9 +145,68 @@ export async function evaluateRepositoryAttention(
 
       await tx
         .update(attentionItems)
-        .set({ status: "RESOLVED", resolvedAt: now })
+        .set({ status: "RESOLVED", resolvedAt: params.now })
         .where(eq(attentionItems.id, item.id));
     }
+  });
+}
+
+export async function evaluateRepositoryTimeAttention(repositoryId: string, now = new Date()) {
+  const repository = await loadRepositoryContext(repositoryId);
+  const [pullRequests, issues] = await loadTimeBasedResources(repositoryId);
+  const findings = evaluateTimeBasedResources(pullRequests, issues, now);
+
+  await reconcileRepositoryFindings({
+    repositoryId,
+    projectId: repository.projectId,
+    findings,
+    ruleIds: TIME_RULE_IDS,
+    now,
+  });
+
+  return {
+    active: findings.length,
+    findings,
+    evaluatedAt: now,
+  };
+}
+
+export async function evaluateRepositoryAttention(
+  repositoryId: string,
+  now = new Date(),
+  relevantWorkflowBranches?: Iterable<string>,
+) {
+  const repository = await loadRepositoryContext(repositoryId);
+  const [[pullRequests, issues], workflowRuns] = await Promise.all([
+    loadTimeBasedResources(repositoryId),
+    db
+      .select({
+        githubRunId: githubWorkflowRuns.githubRunId,
+        workflowName: githubWorkflowRuns.workflowName,
+        branch: githubWorkflowRuns.branch,
+        status: githubWorkflowRuns.status,
+        conclusion: githubWorkflowRuns.conclusion,
+        createdAt: githubWorkflowRuns.createdAtGithub,
+      })
+      .from(githubWorkflowRuns)
+      .where(eq(githubWorkflowRuns.repositoryId, repositoryId)),
+  ]);
+
+  const findings = evaluateTimeBasedResources(pullRequests, issues, now);
+  findings.push(
+    ...evaluateWorkflows({
+      repositoryId,
+      runs: workflowRuns,
+      relevantBranches: relevantWorkflowBranches ?? [repository.defaultBranch],
+    }),
+  );
+
+  await reconcileRepositoryFindings({
+    repositoryId,
+    projectId: repository.projectId,
+    findings,
+    ruleIds: RULE_IDS,
+    now,
   });
 
   return {

--- a/src/modules/attention/scheduled.ts
+++ b/src/modules/attention/scheduled.ts
@@ -1,0 +1,86 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { githubInstallations, projects, repositories } from "@/db/schema";
+import { evaluateRepositoryTimeAttention } from "@/modules/attention/engine";
+import { recalculateProjectHealth } from "@/modules/health/engine";
+
+export type ScheduledAttentionRun = {
+  repositoriesDiscovered: number;
+  repositoriesEvaluated: number;
+  repositoryFailures: number;
+  activeTimeFindings: number;
+  projectsRecalculated: number;
+  healthFailures: number;
+  durationMs: number;
+  completedAt: Date;
+};
+
+export function isCronRequestAuthorized(authorization: string | null, secret: string | undefined) {
+  return Boolean(secret && authorization === `Bearer ${secret}`);
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+export async function runScheduledAttentionEvaluation(now = new Date()): Promise<ScheduledAttentionRun> {
+  const startedAt = Date.now();
+  const connectedRepositories = await db
+    .select({ repositoryId: repositories.id, projectId: repositories.projectId })
+    .from(repositories)
+    .innerJoin(projects, eq(projects.id, repositories.projectId))
+    .innerJoin(githubInstallations, eq(githubInstallations.id, repositories.installationId))
+    .where(and(eq(projects.status, "ACTIVE"), eq(githubInstallations.status, "ACTIVE")));
+
+  const projectIds = new Set<string>();
+  let repositoriesEvaluated = 0;
+  let repositoryFailures = 0;
+  let activeTimeFindings = 0;
+
+  for (const repository of connectedRepositories) {
+    try {
+      const result = await evaluateRepositoryTimeAttention(repository.repositoryId, now);
+      repositoriesEvaluated += 1;
+      activeTimeFindings += result.active;
+      projectIds.add(repository.projectId);
+    } catch (error) {
+      repositoryFailures += 1;
+      console.error("scheduled_attention_repository_failed", {
+        repositoryId: repository.repositoryId,
+        projectId: repository.projectId,
+        message: errorMessage(error),
+      });
+    }
+  }
+
+  let projectsRecalculated = 0;
+  let healthFailures = 0;
+
+  for (const projectId of projectIds) {
+    try {
+      await recalculateProjectHealth(projectId, now);
+      projectsRecalculated += 1;
+    } catch (error) {
+      healthFailures += 1;
+      console.error("scheduled_attention_health_failed", { projectId, message: errorMessage(error) });
+    }
+  }
+
+  const result: ScheduledAttentionRun = {
+    repositoriesDiscovered: connectedRepositories.length,
+    repositoriesEvaluated,
+    repositoryFailures,
+    activeTimeFindings,
+    projectsRecalculated,
+    healthFailures,
+    durationMs: Date.now() - startedAt,
+    completedAt: now,
+  };
+
+  console.info("scheduled_attention_completed", {
+    ...result,
+    completedAt: result.completedAt.toISOString(),
+  });
+
+  return result;
+}

--- a/src/modules/attention/scheduled.ts
+++ b/src/modules/attention/scheduled.ts
@@ -15,10 +15,6 @@ export type ScheduledAttentionRun = {
   completedAt: Date;
 };
 
-export function isCronRequestAuthorized(authorization: string | null, secret: string | undefined) {
-  return Boolean(secret && authorization === `Bearer ${secret}`);
-}
-
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : "unknown error";
 }

--- a/tests/cron-auth.test.ts
+++ b/tests/cron-auth.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isCronRequestAuthorized } from "@/modules/attention/cron-auth";
+
+describe("scheduled Attention cron authorization", () => {
+  it("accepts the exact bearer secret", () => {
+    expect(isCronRequestAuthorized("Bearer devboard-cron-secret", "devboard-cron-secret")).toBe(true);
+  });
+
+  it("rejects missing or incorrect credentials", () => {
+    expect(isCronRequestAuthorized(null, "devboard-cron-secret")).toBe(false);
+    expect(isCronRequestAuthorized("Bearer wrong", "devboard-cron-secret")).toBe(false);
+    expect(isCronRequestAuthorized("devboard-cron-secret", "devboard-cron-secret")).toBe(false);
+    expect(isCronRequestAuthorized("Bearer devboard-cron-secret", undefined)).toBe(false);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/attention",
+      "schedule": "0 9 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #21, #31, #32 and #34.

Adds a production cron route for deterministic time-based Attention evaluation. The scheduled pass evaluates PR_WAITING_REVIEW and STALE_ISSUE without touching workflow alerts, reconciles Attention idempotently, resolves conditions that no longer match, and recalculates Project Health for affected projects. The route is protected by CRON_SECRET and logs aggregate/safe execution data.

The native Vercel schedule runs once per day at 09:00 UTC because the current project is on Hobby, where cron schedules cannot run more than once per day. The implementation is frequency-agnostic so we can later move to hourly evaluation without changing the rule model.

Also documents the production setup and adds cron authorization coverage.