### PR TITLE
chore: establish engineering baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Resumo
+
+Descreva objetivamente o que mudou e por quê.
+
+## Tipo de mudança
+
+- [ ] `feat` nova funcionalidade
+- [ ] `fix` correção de bug
+- [ ] `refactor` refatoração sem mudança funcional
+- [ ] `test` testes
+- [ ] `docs` documentação
+- [ ] `chore` manutenção/infraestrutura
+
+## Validação
+
+- [ ] Rodei os checks locais aplicáveis
+- [ ] TypeScript/typecheck passou
+- [ ] Testes passaram
+- [ ] Build passou quando aplicável
+- [ ] Não adicionei secrets, tokens ou dados sensíveis
+- [ ] Atualizei documentação quando necessário
+
+## Risco e impacto
+
+Descreva riscos, migrações, variáveis de ambiente ou impacto em produção. Use `N/A` se não houver.
+
+## Evidências
+
+Adicione screenshots, logs ou passos de teste quando ajudarem a revisar a mudança.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   secrets-scan:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Padroniza a base de engenharia sem alterar comportamento da aplicação.

Inclui Dependabot semanal para npm e GitHub Actions, template padrão de Pull Request e varredura automática de secrets com Gitleaks.

O CI atual de lint, typecheck, testes e build foi preservado.